### PR TITLE
Feat: add drag and drop command reordering

### DIFF
--- a/cmd/gomander/frontend/src/components/layout/AppSidebarLayout/components/AppSidebar/components/AllCommandsSection/AllCommandsSection.tsx
+++ b/cmd/gomander/frontend/src/components/layout/AppSidebarLayout/components/AppSidebar/components/AllCommandsSection/AllCommandsSection.tsx
@@ -74,7 +74,7 @@ export const AllCommandsSection = () => {
                 asChild
                 className="group/label text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground text-sm"
               >
-                <CollapsibleTrigger className="group flex items-center gap-2 p-2 w-full">
+                <CollapsibleTrigger className="group flex items-center gap-2 p-2 pl-1 w-full">
                   <ChevronDown className="hidden group-data-[state=open]:block" />
                   <ChevronRight className="block group-data-[state=open]:hidden" />
                   <p>All commands</p>
@@ -87,7 +87,7 @@ export const AllCommandsSection = () => {
               </ContextMenuItem>
             </ContextMenuContent>
           </ContextMenu>
-          <CollapsibleContent className="pl-4">
+          <CollapsibleContent>
             <SidebarGroupContent>
               <SidebarMenu>
                 <DndContext onDragEnd={handleDragEnd}>

--- a/cmd/gomander/frontend/src/contracts/service.ts
+++ b/cmd/gomander/frontend/src/contracts/service.ts
@@ -17,6 +17,7 @@ import {
   IsThereANewRelease,
   OpenProject,
   RemoveCommand,
+  ReorderCommands,
   RunCommand,
   SaveCommandGroups,
   SaveUserConfig,
@@ -29,6 +30,7 @@ import { BrowserOpenURL, EventsOff, EventsOn } from "../../wailsjs/runtime";
 export const dataService = {
   addCommand: AddCommand,
   editCommand: EditCommand,
+  reorderCommands: ReorderCommands,
   getAvailableProjects: GetAvailableProjects,
   getCommandGroups: GetCommandGroups,
   getCommands: GetCommands,

--- a/cmd/gomander/frontend/src/useCases/command/reoderCommands.ts
+++ b/cmd/gomander/frontend/src/useCases/command/reoderCommands.ts
@@ -1,0 +1,5 @@
+import { dataService } from "@/contracts/service.ts";
+
+export const reorderCommands = async (newOrder: string[]) => {
+  await dataService.reorderCommands(newOrder);
+};


### PR DESCRIPTION
# Add drag & drop command reordering

## Problem
Users couldn't reorder commands to organize them according to their workflow preferences.

## Solution  
- Added drag & drop functionality to the "All Commands" section
- Connected frontend to backend reordering API from previous PR #78 
- Consistent drag behavior matching existing command groups functionality

## Result
✅ Intuitive command organization  
✅ Improved workflow efficiency  
✅ Unified drag & drop experience across the app