### PR TITLE
feat: add reorder mode for command groups in sidebar

### DIFF
--- a/cmd/gomander/frontend/src/components/layout/AppSidebarLayout/components/AppSidebar/AppSidebar.tsx
+++ b/cmd/gomander/frontend/src/components/layout/AppSidebarLayout/components/AppSidebar/AppSidebar.tsx
@@ -149,9 +149,9 @@ export const AppSidebar = () => {
           </div>
           <CreateMenu />
         </SidebarHeader>
-        <SidebarContent className="gap-0">
+        <SidebarContent className="gap-1">
           <AllCommandsSection />
-          <div className="flex items-center pl-4 pr-2 mt-4 mb-1 gap-2">
+          <div className="flex items-center pl-4 pr-2 mt-2 mb-1 gap-2">
             <h3 className="text-sm text-muted-foreground">Command groups</h3>
             <Tooltip delayDuration={1000}>
               <TooltipContent>

--- a/cmd/gomander/frontend/src/components/layout/AppSidebarLayout/components/AppSidebar/AppSidebar.tsx
+++ b/cmd/gomander/frontend/src/components/layout/AppSidebarLayout/components/AppSidebar/AppSidebar.tsx
@@ -76,20 +76,14 @@ export const AppSidebar = () => {
     navigate(ScreenRoutes.Settings, { state: { tab } });
   };
 
-  const handleDragEnd = async (event: DragEndEvent) => {
-    const ogGroups = [...commandGroups];
+  const handleCommandGroupDragEnd = async (event: DragEndEvent) => {
     const { active, over } = event;
 
     if (active.id && over?.id && active.id !== over.id) {
-      const oldIndex = ogGroups.findIndex((cg) => cg.id === active.id);
-      const newIndex = ogGroups.findIndex((cg) => cg.id === over.id);
-      const newCommandGroups = arrayMove(ogGroups, oldIndex, newIndex);
+      const oldIndex = commandGroups.findIndex((cg) => cg.id === active.id);
+      const newIndex = commandGroups.findIndex((cg) => cg.id === over.id);
+      const newCommandGroups = arrayMove(commandGroups, oldIndex, newIndex);
       setCommandGroups(newCommandGroups);
-      try {
-        await reorderCommandGroups(newCommandGroups.map((cg) => cg.id));
-      } catch {
-        setCommandGroups(ogGroups);
-      }
     }
   };
 
@@ -99,7 +93,12 @@ export const AppSidebar = () => {
   };
 
   const toggleReorderingMode = () => {
-    setIsReorderingGroups((prev) => !prev);
+    setIsReorderingGroups((wasReordering) => {
+      if (wasReordering) {
+        reorderCommandGroups(commandGroups.map((cg) => cg.id));
+      }
+      return !wasReordering;
+    });
   };
 
   return (
@@ -173,7 +172,7 @@ export const AppSidebar = () => {
               </TooltipTrigger>
             </Tooltip>
           </div>
-          <DndContext onDragEnd={handleDragEnd}>
+          <DndContext onDragEnd={handleCommandGroupDragEnd}>
             <SortableContext
               items={commandGroups.map((cg) => cg.id)}
               strategy={verticalListSortingStrategy}

--- a/cmd/gomander/frontend/src/components/layout/AppSidebarLayout/components/AppSidebar/components/CommandGroupSection/CommandGroupSection.tsx
+++ b/cmd/gomander/frontend/src/components/layout/AppSidebarLayout/components/AppSidebar/components/CommandGroupSection/CommandGroupSection.tsx
@@ -19,6 +19,7 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar.tsx";
 import type { Command, CommandGroup } from "@/contracts/types.ts";
+import { cn } from "@/lib/utils.ts";
 import { useCommandStore } from "@/store/commandStore.ts";
 import { CommandStatus } from "@/types/CommandStatus.ts";
 import { deleteCommandGroup } from "@/useCases/commandGroup/deleteCommandGroup.ts";
@@ -92,7 +93,10 @@ export const CommandGroupSection = ({
         <ContextMenuTrigger disabled={isReorderingGroups}>
           <SidebarGroupLabel
             asChild
-            className="text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground text-sm"
+            className={cn(
+              "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground text-sm border-2 border-transparent",
+              isReorderingGroups && "border-dashed border-muted-foreground/30",
+            )}
           >
             <button
               className="group flex items-center gap-2 p-2 w-full justify-between"

--- a/cmd/gomander/frontend/src/components/layout/AppSidebarLayout/components/AppSidebar/components/CommandGroupSection/CommandGroupSection.tsx
+++ b/cmd/gomander/frontend/src/components/layout/AppSidebarLayout/components/AppSidebar/components/CommandGroupSection/CommandGroupSection.tsx
@@ -1,21 +1,10 @@
-import { DndContext, type DragEndEvent } from "@dnd-kit/core";
-import {
-  arrayMove,
-  SortableContext,
-  useSortable,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
+import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { Folder, FolderOpen, GripVertical, Play, Square } from "lucide-react";
-import type { SyntheticEvent } from "react";
+import { Folder, FolderOpen, Play, Square } from "lucide-react";
+import { type SyntheticEvent, useState } from "react";
 
 import { CommandMenuItem } from "@/components/layout/AppSidebarLayout/components/AppSidebar/components/CommandMenuItem/CommandMenuItem.tsx";
 import { useSidebarContext } from "@/components/layout/AppSidebarLayout/components/AppSidebar/contexts/sidebarContext.tsx";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible.tsx";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -33,7 +22,6 @@ import type { Command, CommandGroup } from "@/contracts/types.ts";
 import { useCommandStore } from "@/store/commandStore.ts";
 import { CommandStatus } from "@/types/CommandStatus.ts";
 import { deleteCommandGroup } from "@/useCases/commandGroup/deleteCommandGroup.ts";
-import { reorderCommandGroupCommands } from "@/useCases/commandGroup/reoderCommandGroupCommands.ts";
 import { runCommandGroup } from "@/useCases/commandGroup/runCommandGroup.ts";
 import { stopCommandGroup } from "@/useCases/commandGroup/stopCommandGroup.ts";
 
@@ -44,10 +32,13 @@ export const CommandGroupSection = ({
 }) => {
   const commandsStatus = useCommandStore((state) => state.commandsStatus);
 
-  const { startEditingCommandGroup } = useSidebarContext();
+  const { startEditingCommandGroup, isReorderingGroups } = useSidebarContext();
+
+  const [internalIsOpen, setInternalIsOpen] = useState(false);
+  const isOpen = internalIsOpen && !isReorderingGroups;
 
   const { attributes, listeners, setNodeRef, transform, transition } =
-    useSortable({ id: commandGroup.id });
+    useSortable({ id: commandGroup.id, disabled: !isReorderingGroups });
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -67,6 +58,8 @@ export const CommandGroupSection = ({
   const run = (e: SyntheticEvent) => {
     // Prevent the folder from collapsing when clicking the play button
     e.stopPropagation();
+
+    if (isReorderingGroups) return;
     runCommandGroup(commandGroup.id);
   };
 
@@ -74,84 +67,45 @@ export const CommandGroupSection = ({
     // Prevent the folder from collapsing when clicking the stop button
     e.stopPropagation();
 
+    if (isReorderingGroups) return;
     stopCommandGroup(commandGroup.id);
   };
 
   const handleDelete = async () => {
+    if (isReorderingGroups) return;
     await deleteCommandGroup(commandGroup.id);
   };
 
   const handleEdit = () => {
+    if (isReorderingGroups) return;
     startEditingCommandGroup(commandGroup);
   };
 
-  const handleSaveReorderedCommandGroup = async (
-    reorderedCommandGroup: CommandGroup,
-  ) => {
-    await reorderCommandGroupCommands(reorderedCommandGroup);
-  };
-
-  const handleDragEnd = async (event: DragEndEvent) => {
-    const { active, over } = event;
-
-    if (active.id && over?.id && active.id !== over.id) {
-      const oldIndex = commandGroup.commands.findIndex(
-        (cmd) => cmd.id === active.id,
-      );
-      const newIndex = commandGroup.commands.findIndex(
-        (cmd) => cmd.id === over.id,
-      );
-      const newCommandsGroups = arrayMove(
-        commandGroup.commands,
-        oldIndex,
-        newIndex,
-      );
-      const reorderedCommandGroup = {
-        ...commandGroup,
-        commands: newCommandsGroups,
-      };
-
-      await handleSaveReorderedCommandGroup(reorderedCommandGroup);
-    }
-  };
-
   return (
-    <Collapsible
+    <SidebarGroup
+      className="py-0"
       key={commandGroup.id}
-      className="group/collapsible"
       style={style}
       ref={setNodeRef}
     >
-      <SidebarGroup className="py-0">
-        <ContextMenu>
-          <ContextMenuTrigger>
-            <SidebarGroupLabel
-              asChild
-              className="group/label text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground text-sm"
+      <ContextMenu>
+        <ContextMenuTrigger disabled={isReorderingGroups}>
+          <SidebarGroupLabel
+            asChild
+            className="text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground text-sm"
+          >
+            <button
+              className="group flex items-center gap-2 p-2 w-full justify-between"
+              style={{ cursor: isReorderingGroups ? "grabbing" : "pointer" }}
+              onClick={() => setInternalIsOpen(!internalIsOpen)}
+              disabled={isReorderingGroups}
+              {...(isReorderingGroups ? { ...attributes, ...listeners } : {})}
             >
-              <CollapsibleTrigger className="group flex items-center gap-2 p-2 w-full justify-between">
-                <div className="flex items-center gap-2">
-                  <div
-                    {...attributes}
-                    {...listeners}
-                    className="cursor-grab active:cursor-grabbing rounded hover:bg-sidebar-accent/50 group-data-[state=open]:hidden transition-transform"
-                  >
-                    <GripVertical size={14} className="text-muted-foreground" />
-                  </div>
-                  <GripVertical
-                    size={14}
-                    className="hidden group-data-[state=open]:block text-muted-foreground/50 cursor-not-allowed"
-                  />
-                  <FolderOpen
-                    size={16}
-                    className="hidden group-data-[state=open]:block"
-                  />
-                  <Folder
-                    size={16}
-                    className="block group-data-[state=open]:hidden"
-                  />
-                  <p>{commandGroup.name}</p>
-                </div>
+              <div className="flex items-center gap-2">
+                {isOpen ? <FolderOpen size={16} /> : <Folder size={16} />}
+                <p>{commandGroup.name}</p>
+              </div>
+              {!isReorderingGroups && (
                 <div className="flex gap-2 items-center">
                   {someCommandIsRunning && (
                     <span>
@@ -175,33 +129,26 @@ export const CommandGroupSection = ({
                     </div>
                   )}
                 </div>
-              </CollapsibleTrigger>
-            </SidebarGroupLabel>
-          </ContextMenuTrigger>
-          <ContextMenuContent>
-            <ContextMenuItem onClick={handleEdit}>Edit</ContextMenuItem>
-            <ContextMenuItem onClick={handleDelete}>Delete</ContextMenuItem>
-          </ContextMenuContent>
-        </ContextMenu>
-        <CollapsibleContent className="pl-4">
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <DndContext onDragEnd={handleDragEnd}>
-                <SortableContext
-                  strategy={verticalListSortingStrategy}
-                  items={commandGroup.commands}
-                >
-                  {commandGroup.commands.map((command) => (
-                    <SidebarMenuItem key={command.id}>
-                      <CommandMenuItem draggable command={command} />
-                    </SidebarMenuItem>
-                  ))}
-                </SortableContext>
-              </DndContext>
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </CollapsibleContent>
-      </SidebarGroup>
-    </Collapsible>
+              )}
+            </button>
+          </SidebarGroupLabel>
+        </ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuItem onClick={handleEdit}>Edit</ContextMenuItem>
+          <ContextMenuItem onClick={handleDelete}>Delete</ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
+      {isOpen && (
+        <SidebarGroupContent>
+          <SidebarMenu>
+            {commandGroup.commands.map((command) => (
+              <SidebarMenuItem key={command.id}>
+                <CommandMenuItem command={command} />
+              </SidebarMenuItem>
+            ))}
+          </SidebarMenu>
+        </SidebarGroupContent>
+      )}
+    </SidebarGroup>
   );
 };

--- a/cmd/gomander/frontend/src/components/layout/AppSidebarLayout/components/AppSidebar/components/CommandMenuItem/CommandMenuItem.tsx
+++ b/cmd/gomander/frontend/src/components/layout/AppSidebarLayout/components/AppSidebar/components/CommandMenuItem/CommandMenuItem.tsx
@@ -99,11 +99,16 @@ export const CommandMenuItem = ({
         <SidebarMenuButton asChild className={className}>
           <div
             onClick={onCommandSectionClick}
-            className="flex flex-row justify-between items-center w-full"
+            className="flex flex-row justify-between items-center w-full select-none"
             ref={setNodeRef}
             style={style}
           >
-            <div className="flex items-center gap-1 w-full text-sm text-sidebar-foreground">
+            <div
+              className={cn(
+                "flex items-center gap-1 w-full text-sm text-sidebar-foreground",
+                !draggable && "pl-2",
+              )}
+            >
               {draggable && (
                 <div
                   {...attributes}
@@ -113,7 +118,7 @@ export const CommandMenuItem = ({
                   <GripVertical size={14} className="text-muted-foreground" />
                 </div>
               )}
-              {command.name}
+              <span className="cursor-default">{command.name}</span>
             </div>
             {isIdle && (
               <Play

--- a/cmd/gomander/frontend/src/components/layout/AppSidebarLayout/components/AppSidebar/contexts/sidebarContext.tsx
+++ b/cmd/gomander/frontend/src/components/layout/AppSidebarLayout/components/AppSidebar/contexts/sidebarContext.tsx
@@ -5,10 +5,12 @@ import type { Command, CommandGroup } from "@/contracts/types.ts";
 export const sidebarContext = createContext<{
   startEditingCommand: (command: Command) => void;
   startEditingCommandGroup: (commandGroup: CommandGroup) => void;
+  isReorderingGroups: boolean;
 }>(
   {} as {
     startEditingCommand: (command: Command) => void;
     startEditingCommandGroup: (commandGroup: CommandGroup) => void;
+    isReorderingGroups: boolean;
   },
 );
 


### PR DESCRIPTION
# Add reorder mode for command groups

Implements a dedicated reorder mode for command groups in the sidebar to improve UX, prevent accidental reordering and reduce too many icons noise.

## Changes

- [x] Add reorder toggle button next to "Command groups" title
- [x] Groups collapse and become draggable only when reorder mode is active
- [x] Disable all group functionality (play, stop, edit, delete) during reordering
- [x] Remove drag handles for cleaner interface
- [x] Changes are applied to backend when exiting reorder mode
- [x] Visual UI change when reordering (added dashed border to groups)

## UX improvements
- Separates normal usage from reordering workflow
- Prevents accidental drag operations
- Cleaner sidebar interface without persistent drag handles