### PR TITLE
fix: avoid goose from trying to import migrations in the executable filepath

### DIFF
--- a/cmd/gomander/main.go
+++ b/cmd/gomander/main.go
@@ -108,6 +108,8 @@ func configDB(ctx context.Context) *gorm.DB {
 		panic(err)
 	}
 
+	goose.SetBaseFS(embed.FS{})
+
 	err = goose.UpContext(ctx, db, ".")
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
This pull request makes a small update to the database migration setup in `cmd/gomander/main.go`. It sets the base filesystem for Goose migrations to an empty embedded filesystem before running migrations. This change avoids the problems while executing the binary in a folder with other .sql files