### PR TITLE
feat: add tooltip when create command group is disabled

### DIFF
--- a/cmd/gomander/frontend/src/components/layout/AppSidebarLayout/components/AppSidebar/components/CreateMenu/CreateMenu.tsx
+++ b/cmd/gomander/frontend/src/components/layout/AppSidebarLayout/components/AppSidebar/components/CreateMenu/CreateMenu.tsx
@@ -11,6 +11,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip.tsx";
 import { useCommandStore } from "@/store/commandStore.ts";
 
 export const CreateMenu = () => {
@@ -52,14 +57,24 @@ export const CreateMenu = () => {
             <Terminal />
             Command
           </DropdownMenuItem>
-          <DropdownMenuItem
-            onClick={openCreateCommandGroupModal}
-            className="flex flex-row items-center justify-start"
-            disabled={!hasCommands}
-          >
-            <Group />
-            Command Group
-          </DropdownMenuItem>
+          <Tooltip delayDuration={500}>
+            <TooltipTrigger>
+              <DropdownMenuItem
+                onClick={openCreateCommandGroupModal}
+                className="flex flex-row items-center justify-start"
+                disabled={!hasCommands}
+              >
+                <Group />
+                Command Group
+              </DropdownMenuItem>
+            </TooltipTrigger>
+            {!hasCommands && (
+              <TooltipContent side="bottom">
+                Groups don't make sense without commands! Create a command
+                first.
+              </TooltipContent>
+            )}
+          </Tooltip>
         </DropdownMenuContent>
       </DropdownMenu>
     </>


### PR DESCRIPTION
This PR enhances the user experience in the `CreateMenu` component by adding a contextual tooltip that appears when the "Create command group" option is disabled due to the project having no commands, providing clear feedback to users about why the option is unavailable.

<img width="462" height="168" alt="image" src="https://github.com/user-attachments/assets/367e6588-0025-4ddd-b51e-5bbad28be08b" />
