### PR TITLE
Fix incorrect item deletion in environment paths list

### DIFF
--- a/cmd/gomander/frontend/src/screens/SettingsScreen/tabs/ProjectSettings/components/EnvironmentPathsField.tsx
+++ b/cmd/gomander/frontend/src/screens/SettingsScreen/tabs/ProjectSettings/components/EnvironmentPathsField.tsx
@@ -26,14 +26,15 @@ export const EnvironmentPathsField = () => {
   const removePath = (index: number) => () => {
     remove(index);
   };
+
   return (
     <div className="flex flex-col items-center">
       {fields.length !== 0 && (
         <div className="flex flex-col gap-2 w-full">
-          {fields.map((_, index) => (
+          {fields.map((field, index) => (
             <div
               className="flex flex-row w-full items-center gap-3 justify-between"
-              key={index}
+              key={field.id}
             >
               <FormField
                 control={control}


### PR DESCRIPTION
Fixes issue #141 where deleting any item in the environment paths list would delete the last item instead.

**Problem**: Using array index as React key caused component reuse when items were removed.

**Solution**: Use the existing `field.id` (UUID) as key for stable component identity.