### PR TITLE
fix: small fixes after moving command groups run and stop to backend

### DIFF
--- a/cmd/gomander/frontend/src/useCases/commandGroup/runCommandGroup.ts
+++ b/cmd/gomander/frontend/src/useCases/commandGroup/runCommandGroup.ts
@@ -1,5 +1,12 @@
 import { dataService } from "@/contracts/service.ts";
+import { commandGroupStore } from "@/store/commandGroupStore.ts";
+import { cleanCommandLogs } from "@/useCases/command/cleanCommandLogs.ts";
 
 export const runCommandGroup = async (groupId: string) => {
+  const { commandGroups } = commandGroupStore.getState();
+  commandGroups
+    .find((g) => g.id === groupId)
+    ?.commands.forEach((c) => cleanCommandLogs(c.id));
+
   await dataService.runCommandGroup(groupId);
 };

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -2,7 +2,6 @@ package runner
 
 import (
 	"bufio"
-	"errors"
 	"io"
 	"os"
 	"os/exec"
@@ -193,7 +192,7 @@ func (c *DefaultRunner) StopRunningCommand(id string) error {
 	c.mutex.Unlock()
 
 	if !exists {
-		return errors.New("No running command with id: " + id)
+		return nil
 	}
 
 	return StopProcessGracefully(runningCommand.cmd)


### PR DESCRIPTION
This pull request primarily refactors error handling in the command runner logic, focusing on the behavior when attempting to stop commands that are not running. It also updates the frontend to clear command logs before running a command group. The key changes are grouped below:

### Backend error handling improvements

* The `StopRunningCommand` method in `internal/runner/runner.go` now returns `nil` instead of an error when trying to stop a command that isn't running, making stopping non-existent commands a no-op.
* Related tests in `internal/runner/runner_test.go` have been updated: tests that previously expected errors when stopping non-existent commands have been removed or changed to expect no error, aligning with the new backend behavior. [[1]](diffhunk://#diff-3b8985514864e913f3a3b3463fc897dd19897655c1b71ae44b0928b5b5a94f7fL192-L206) [[2]](diffhunk://#diff-3b8985514864e913f3a3b3463fc897dd19897655c1b71ae44b0928b5b5a94f7fL457-L519) [[3]](diffhunk://#diff-3b8985514864e913f3a3b3463fc897dd19897655c1b71ae44b0928b5b5a94f7fL549-R472)
* The unused import of `errors` has been removed from `internal/runner/runner.go`, reflecting the reduced need for error handling in this context.

### Frontend command log management

* The `runCommandGroup` use case in `cmd/gomander/frontend/src/useCases/commandGroup/runCommandGroup.ts` now clears logs for each command in the group before executing, ensuring a clean log state for each run.