### PR TITLE
Fix folder picker button overlapping long paths in FSInput

### DIFF
--- a/cmd/gomander/frontend/src/components/inputs/FSInput.tsx
+++ b/cmd/gomander/frontend/src/components/inputs/FSInput.tsx
@@ -3,6 +3,7 @@ import type { ChangeEvent } from "react";
 
 import { Input } from "@/components/ui/input.tsx";
 import { helpersService } from "@/contracts/service.ts";
+import { cn } from "@/lib/utils.ts";
 
 export const FSInput = (props: React.ComponentProps<typeof Input>) => {
   const handleAskForDirPath = async () => {
@@ -16,7 +17,7 @@ export const FSInput = (props: React.ComponentProps<typeof Input>) => {
 
   return (
     <div className="w-full relative">
-      <Input {...props} />
+      <Input {...props} className={cn("pr-8", props.className)} />
       <button
         onClick={handleAskForDirPath}
         className="absolute right-2 top-2 z-10 bg-background"


### PR DESCRIPTION
## Problem

The folder picker button was positioned absolutely over the input field, causing it to overlap with long file paths.

## Solution

Added `pr-8` padding to the input to reserve space for the button, preventing text overlap.

### Before
<img width="309" height="88" alt="image" src="https://github.com/user-attachments/assets/df5b5bdc-271e-4aac-807e-ecd290dc7990" />


### After
<img width="309" height="93" alt="image" src="https://github.com/user-attachments/assets/d604b647-90cb-4209-b833-2fc0358d0f8d" />
