### PR TITLE
POC Server for 3rd party integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,11 @@ When Gomander starts, it automatically launches the API server on an available p
 The API provides the following main endpoints:
 
 - **GET /commands** - List all commands with their status (running/stopped)
-- **POST /command/run/{id}** - Run a specific command
-- **POST /command/stop/{id}** - Stop a running command
+- **POST /commands/{id}/run** - Run a specific command
+- **POST /commands/{id}/stop** - Stop a running command
 - **GET /command-groups** - List all command groups with information about running commands
-- **POST /command-group/run/{id}** - Run all commands in a group
-- **POST /command-group/stop/{id}** - Stop all running commands in a group
+- **POST /command-groups/{id}/run** - Run all commands in a group
+- **POST /command-groups/{id}/stop** - Stop all running commands in a group
 
 ### OpenAPI Specification
 

--- a/README.md
+++ b/README.md
@@ -90,3 +90,40 @@ Want to see more specific build options? Check them out with:
 ```bash
 make help
 ```
+
+## Third-Party API Integration
+
+Gomander provides a REST API that enables integration with third-party applications and tools. This API allows you to interact with commands and command groups programmatically.
+
+### API Discovery
+
+When Gomander starts, it automatically launches the API server on an available port in the range 9001-9100. To discover the API:
+
+1. Send a GET request to any port in this range with the path `/discovery`
+2. The first port that responds with a 200 OK status and the following JSON payload is the active Gomander API endpoint:
+   ```json
+   {
+     "app": "Gomander"
+   }
+   ```
+
+### Available Endpoints
+
+The API provides the following main endpoints:
+
+- **GET /commands** - List all commands with their status (running/stopped)
+- **POST /command/run/{id}** - Run a specific command
+- **POST /command/stop/{id}** - Stop a running command
+- **GET /command-groups** - List all command groups with information about running commands
+- **POST /command-group/run/{id}** - Run all commands in a group
+- **POST /command-group/stop/{id}** - Stop all running commands in a group
+
+### OpenAPI Specification
+
+For complete API documentation, refer to the OpenAPI specification file located at:
+
+```
+/cmd/gomander/thirdpartyserver/openapi.yaml
+```
+
+This specification provides detailed information about all endpoints, request parameters, response formats, and possible error codes.

--- a/cmd/gomander/frontend/src/components/utility/EventListenersContainer.tsx
+++ b/cmd/gomander/frontend/src/components/utility/EventListenersContainer.tsx
@@ -1,13 +1,13 @@
-import { Fragment, useEffect, useRef } from "react";
+import {Fragment, useEffect, useRef} from "react";
 
-import { getCommandGroupSectionOpenLocalStorageKey } from "@/constants/localStorage.ts";
-import { eventService } from "@/contracts/service.ts";
-import { Event, type EventData } from "@/contracts/types.ts";
-import { removeKeyFromLocalStorage } from "@/helpers/localStorage.ts";
-import { useCommandStore } from "@/store/commandStore.ts";
-import { CommandStatus } from "@/types/CommandStatus.ts";
-import { cleanCommandLogs } from "@/useCases/command/cleanCommandLogs.ts";
-import { updateCommandStatus } from "@/useCases/command/updateCommandStatus.ts";
+import {getCommandGroupSectionOpenLocalStorageKey} from "@/constants/localStorage.ts";
+import {eventService} from "@/contracts/service.ts";
+import {Event, type EventData} from "@/contracts/types.ts";
+import {removeKeyFromLocalStorage} from "@/helpers/localStorage.ts";
+import {useCommandStore} from "@/store/commandStore.ts";
+import {CommandStatus} from "@/types/CommandStatus.ts";
+import {cleanCommandLogs} from "@/useCases/command/cleanCommandLogs.ts";
+import {updateCommandStatus} from "@/useCases/command/updateCommandStatus.ts";
 
 export const EventListenersContainer = () => {
   const addLogs = useCommandStore((state) => state.addLogs);
@@ -49,8 +49,8 @@ export const EventListenersContainer = () => {
       Event.PROCESS_STARTED,
       (data: EventData[Event.PROCESS_STARTED]) =>
         {
-          updateCommandStatus(data, CommandStatus.RUNNING)
-          cleanCommandLogs(data)
+          updateCommandStatus(data, CommandStatus.RUNNING);
+          cleanCommandLogs(data);
         }
     );
 

--- a/cmd/gomander/frontend/src/components/utility/EventListenersContainer.tsx
+++ b/cmd/gomander/frontend/src/components/utility/EventListenersContainer.tsx
@@ -1,13 +1,13 @@
-import {Fragment, useEffect, useRef} from "react";
+import { Fragment, useEffect, useRef } from "react";
 
-import {getCommandGroupSectionOpenLocalStorageKey} from "@/constants/localStorage.ts";
-import {eventService} from "@/contracts/service.ts";
-import {Event, type EventData} from "@/contracts/types.ts";
-import {removeKeyFromLocalStorage} from "@/helpers/localStorage.ts";
-import {useCommandStore} from "@/store/commandStore.ts";
-import {CommandStatus} from "@/types/CommandStatus.ts";
-import {cleanCommandLogs} from "@/useCases/command/cleanCommandLogs.ts";
-import {updateCommandStatus} from "@/useCases/command/updateCommandStatus.ts";
+import { getCommandGroupSectionOpenLocalStorageKey } from "@/constants/localStorage.ts";
+import { eventService } from "@/contracts/service.ts";
+import { Event, type EventData } from "@/contracts/types.ts";
+import { removeKeyFromLocalStorage } from "@/helpers/localStorage.ts";
+import { useCommandStore } from "@/store/commandStore.ts";
+import { CommandStatus } from "@/types/CommandStatus.ts";
+import { cleanCommandLogs } from "@/useCases/command/cleanCommandLogs.ts";
+import { updateCommandStatus } from "@/useCases/command/updateCommandStatus.ts";
 
 export const EventListenersContainer = () => {
   const addLogs = useCommandStore((state) => state.addLogs);
@@ -47,11 +47,10 @@ export const EventListenersContainer = () => {
 
     eventService.eventsOn(
       Event.PROCESS_STARTED,
-      (data: EventData[Event.PROCESS_STARTED]) =>
-        {
-          updateCommandStatus(data, CommandStatus.RUNNING);
-          cleanCommandLogs(data);
-        }
+      (data: EventData[Event.PROCESS_STARTED]) => {
+        updateCommandStatus(data, CommandStatus.RUNNING);
+        cleanCommandLogs(data);
+      },
     );
 
     eventService.eventsOn(

--- a/cmd/gomander/frontend/src/components/utility/EventListenersContainer.tsx
+++ b/cmd/gomander/frontend/src/components/utility/EventListenersContainer.tsx
@@ -6,6 +6,7 @@ import { Event, type EventData } from "@/contracts/types.ts";
 import { removeKeyFromLocalStorage } from "@/helpers/localStorage.ts";
 import { useCommandStore } from "@/store/commandStore.ts";
 import { CommandStatus } from "@/types/CommandStatus.ts";
+import { cleanCommandLogs } from "@/useCases/command/cleanCommandLogs.ts";
 import { updateCommandStatus } from "@/useCases/command/updateCommandStatus.ts";
 
 export const EventListenersContainer = () => {
@@ -47,7 +48,10 @@ export const EventListenersContainer = () => {
     eventService.eventsOn(
       Event.PROCESS_STARTED,
       (data: EventData[Event.PROCESS_STARTED]) =>
-        updateCommandStatus(data, CommandStatus.RUNNING),
+        {
+          updateCommandStatus(data, CommandStatus.RUNNING)
+          cleanCommandLogs(data)
+        }
     );
 
     eventService.eventsOn(

--- a/cmd/gomander/frontend/src/useCases/command/startCommand.ts
+++ b/cmd/gomander/frontend/src/useCases/command/startCommand.ts
@@ -1,8 +1,5 @@
 import { dataService } from "@/contracts/service.ts";
-import { cleanCommandLogs } from "@/useCases/command/cleanCommandLogs.ts";
 
 export const startCommand = async (commandId: string) => {
-  cleanCommandLogs(commandId);
-
   await dataService.runCommand(commandId);
 };

--- a/cmd/gomander/frontend/src/useCases/commandGroup/runCommandGroup.ts
+++ b/cmd/gomander/frontend/src/useCases/commandGroup/runCommandGroup.ts
@@ -1,12 +1,5 @@
 import { dataService } from "@/contracts/service.ts";
-import { commandGroupStore } from "@/store/commandGroupStore.ts";
-import { cleanCommandLogs } from "@/useCases/command/cleanCommandLogs.ts";
 
 export const runCommandGroup = async (groupId: string) => {
-  const { commandGroups } = commandGroupStore.getState();
-  commandGroups
-    .find((g) => g.id === groupId)
-    ?.commands.forEach((c) => cleanCommandLogs(c.id));
-
   await dataService.runCommandGroup(groupId);
 };

--- a/cmd/gomander/frontend/wailsjs/go/models.ts
+++ b/cmd/gomander/frontend/wailsjs/go/models.ts
@@ -29,6 +29,7 @@ export namespace app {
 	    ReorderCommands: any;
 	    RunCommand: any;
 	    StopCommand: any;
+	    GetRunningCommandIds: any;
 	}
 	export interface EventHandlers {
 	    CleanCommandGroupsOnCommandDeleted: any;

--- a/cmd/gomander/main.go
+++ b/cmd/gomander/main.go
@@ -222,6 +222,7 @@ func registerDeps(gormDb *gorm.DB, ctx context.Context, app *internalapp.App) {
 	reorderCommands := commandusecases.NewReorderCommands(configRepo, commandRepo)
 	runCommand := commandusecases.NewRunCommand(configRepo, commandRepo, projectRepo, r)
 	stopCommand := commandusecases.NewStopCommand(commandRepo, r)
+	getRunningCommandIds := commandusecases.NewGetRunningCommandIds(r)
 
 	app.LoadDependencies(internalapp.Dependencies{
 		Logger:       l,
@@ -269,14 +270,15 @@ func registerDeps(gormDb *gorm.DB, ctx context.Context, app *internalapp.App) {
 			RunCommandGroup:               runCommandGroup,
 			StopCommandGroup:              stopCommandGroup,
 			// Commands
-			GetCommands:      getCommands,
-			AddCommand:       addCommand,
-			DuplicateCommand: duplicateCommand,
-			RemoveCommand:    removeCommand,
-			EditCommand:      editCommand,
-			ReorderCommands:  reorderCommands,
-			RunCommand:       runCommand,
-			StopCommand:      stopCommand,
+			GetCommands:          getCommands,
+			AddCommand:           addCommand,
+			DuplicateCommand:     duplicateCommand,
+			RemoveCommand:        removeCommand,
+			EditCommand:          editCommand,
+			ReorderCommands:      reorderCommands,
+			RunCommand:           runCommand,
+			StopCommand:          stopCommand,
+			GetRunningCommandIds: getRunningCommandIds,
 		},
 	})
 }

--- a/cmd/gomander/main.go
+++ b/cmd/gomander/main.go
@@ -12,6 +12,7 @@ import (
 
 	gormlogger "gorm.io/gorm/logger"
 
+	"gomander/cmd/gomander/thirdpartyserver"
 	"gomander/internal/command/application/handlers"
 	commandusecases "gomander/internal/command/application/usecases"
 	commmandinfrastructure "gomander/internal/command/infrastructure"
@@ -85,13 +86,14 @@ func main() {
 			uiFsHelper.SetContext(ctx)
 
 			// Start http server for 3rd party integrations
-			server := NewThirdPartyIntegrationsServer(app.UseCases)
+			server := thirdpartyserver.NewThirdPartyIntegrationsServer(app.UseCases)
 
 			go func() {
-				err := server.Start()
+				err := server.RegisterHandlers()
 				if err != nil {
 					panic(err)
 				}
+				server.Start()
 			}()
 		},
 		Bind: []interface{}{

--- a/cmd/gomander/main.go
+++ b/cmd/gomander/main.go
@@ -83,6 +83,16 @@ func main() {
 
 			// Load context into helpers
 			uiFsHelper.SetContext(ctx)
+
+			// Start http server for 3rd party integrations
+			server := NewThirdPartyIntegrationsServer(app.UseCases)
+
+			go func() {
+				err := server.Start()
+				if err != nil {
+					panic(err)
+				}
+			}()
 		},
 		Bind: []interface{}{
 			app,

--- a/cmd/gomander/thirdpartyhttpserver.go
+++ b/cmd/gomander/thirdpartyhttpserver.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+
+	"gomander/internal/app"
+	commanddomain "gomander/internal/command/domain"
+	"gomander/internal/commandgroup/domain"
+	"gomander/internal/helpers/array"
+)
+
+type ThirdPartyIntegrationsServer struct {
+	useCases app.UseCases
+	mu       sync.RWMutex
+	server   *http.Server
+}
+
+func NewThirdPartyIntegrationsServer(useCases app.UseCases) *ThirdPartyIntegrationsServer {
+	return &ThirdPartyIntegrationsServer{
+		useCases: useCases,
+	}
+}
+
+func (s *ThirdPartyIntegrationsServer) Start() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.server != nil {
+		return nil // Server is already running
+	}
+
+	mux := http.NewServeMux()
+
+	// Discovery endpoint
+	mux.HandleFunc("/discovery", s.handleDiscovery)
+
+	// Commands and Command Groups endpoints
+	mux.HandleFunc("/commands", s.handleGetCommands)
+	mux.HandleFunc("/command/run/{id}", s.handleRunCommand)
+	mux.HandleFunc("/command/stop/{id}", s.handleStopCommand)
+	//
+	mux.HandleFunc("/command-groups", s.handleGetCommandGroups)
+	mux.HandleFunc("/command-group/run/{id}", s.handleRunCommandGroup)
+	mux.HandleFunc("/command-group/stop/{id}", s.handleStopCommandGroup)
+
+	s.server = &http.Server{
+		Addr:    ":9001",
+		Handler: mux,
+	}
+
+	go func() {
+		if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			// Handle error (log it, etc.)
+			println(err.Error())
+		}
+	}()
+
+	return nil
+}
+
+func (s *ThirdPartyIntegrationsServer) Stop() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.server == nil {
+		return nil // Server is not running
+	}
+
+	err := s.server.Close()
+	s.server = nil
+	return err
+}
+
+func (s *ThirdPartyIntegrationsServer) handleDiscovery(w http.ResponseWriter, r *http.Request) {
+	// Example response for discovery endpoint
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, err := w.Write([]byte(`{"app": "Gomander"}`))
+	if err != nil {
+		println("Error writing response:", err.Error())
+	}
+}
+
+func (s *ThirdPartyIntegrationsServer) handleGetCommands(w http.ResponseWriter, r *http.Request) {
+	commands, err := s.useCases.GetCommands.Execute()
+	if err != nil {
+		http.Error(w, "Failed to get commands", http.StatusInternalServerError)
+		return
+	}
+
+	mappedCommands := array.Map(commands, func(cmd commanddomain.Command) map[string]interface{} {
+		return map[string]interface{}{
+			"id":      cmd.Id,
+			"name":    cmd.Name,
+			"command": cmd.Command,
+		}
+	})
+
+	err = json.NewEncoder(w).Encode(mappedCommands)
+	if err != nil {
+		http.Error(w, "Failed to encode commands", http.StatusInternalServerError)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+}
+
+func (s *ThirdPartyIntegrationsServer) handleRunCommand(w http.ResponseWriter, r *http.Request) {
+	// Extract command ID from URL
+	id := r.PathValue("id")
+	if id == "" {
+		http.Error(w, "Command ID is required", http.StatusBadRequest)
+	}
+
+	err := s.useCases.RunCommand.Execute(id)
+	if err != nil {
+		http.Error(w, "Failed to run command", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *ThirdPartyIntegrationsServer) handleStopCommand(w http.ResponseWriter, r *http.Request) {
+	// Extract command ID from URL
+	id := r.PathValue("id")
+	if id == "" {
+		http.Error(w, "Command ID is required", http.StatusBadRequest)
+	}
+
+	err := s.useCases.StopCommand.Execute(id)
+	if err != nil {
+		http.Error(w, "Failed to stop command", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *ThirdPartyIntegrationsServer) handleGetCommandGroups(w http.ResponseWriter, r *http.Request) {
+	groups, err := s.useCases.GetCommandGroups.Execute()
+	if err != nil {
+		http.Error(w, "Failed to get command groups", http.StatusInternalServerError)
+		return
+	}
+
+	mappedGroups := array.Map(groups, func(group domain.CommandGroup) map[string]interface{} {
+		return map[string]interface{}{
+			"id":   group.Id,
+			"name": group.Name,
+		}
+	})
+
+	err = json.NewEncoder(w).Encode(mappedGroups)
+	if err != nil {
+		http.Error(w, "Failed to encode command groups", http.StatusInternalServerError)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+}
+
+func (s *ThirdPartyIntegrationsServer) handleRunCommandGroup(w http.ResponseWriter, r *http.Request) {
+	// Extract command group ID from URL
+	id := r.PathValue("id")
+	if id == "" {
+		http.Error(w, "Command Group ID is required", http.StatusBadRequest)
+	}
+
+	err := s.useCases.RunCommandGroup.Execute(id)
+	if err != nil {
+		http.Error(w, "Failed to run command group", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *ThirdPartyIntegrationsServer) handleStopCommandGroup(w http.ResponseWriter, r *http.Request) {
+	// Extract command group ID from URL
+	id := r.PathValue("id")
+	if id == "" {
+		http.Error(w, "Command Group ID is required", http.StatusBadRequest)
+	}
+
+	err := s.useCases.StopCommandGroup.Execute(id)
+	if err != nil {
+		http.Error(w, "Failed to stop command group", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/cmd/gomander/thirdpartyserver/handlers.go
+++ b/cmd/gomander/thirdpartyserver/handlers.go
@@ -42,10 +42,9 @@ func (s *ThirdPartyIntegrationsServer) handleGetCommands(w http.ResponseWriter, 
 		}
 
 		return map[string]interface{}{
-			"id":      cmd.Id,
-			"name":    cmd.Name,
-			"command": cmd.Command,
-			"status":  status,
+			"id":     cmd.Id,
+			"name":   cmd.Name,
+			"status": status,
 		}
 	})
 

--- a/cmd/gomander/thirdpartyserver/handlers.go
+++ b/cmd/gomander/thirdpartyserver/handlers.go
@@ -48,12 +48,12 @@ func (s *ThirdPartyIntegrationsServer) handleGetCommands(w http.ResponseWriter, 
 		}
 	})
 
+	w.Header().Set("Content-Type", "application/json")
 	err = json.NewEncoder(w).Encode(mappedCommands)
 	if err != nil {
 		http.Error(w, "Failed to encode commands", http.StatusInternalServerError)
 	}
 
-	w.Header().Set("Content-Type", "application/json")
 }
 
 func (s *ThirdPartyIntegrationsServer) handleRunCommand(w http.ResponseWriter, r *http.Request) {
@@ -64,9 +64,6 @@ func (s *ThirdPartyIntegrationsServer) handleRunCommand(w http.ResponseWriter, r
 
 	// Extract command ID from URL
 	id := r.PathValue("id")
-	if id == "" {
-		http.Error(w, "Command ID is required", http.StatusBadRequest)
-	}
 
 	err := s.useCases.RunCommand.Execute(id)
 	if err != nil {
@@ -83,9 +80,6 @@ func (s *ThirdPartyIntegrationsServer) handleStopCommand(w http.ResponseWriter, 
 
 	// Extract command ID from URL
 	id := r.PathValue("id")
-	if id == "" {
-		http.Error(w, "Command ID is required", http.StatusBadRequest)
-	}
 
 	err := s.useCases.StopCommand.Execute(id)
 	if err != nil {
@@ -118,12 +112,11 @@ func (s *ThirdPartyIntegrationsServer) handleGetCommandGroups(w http.ResponseWri
 		}
 	})
 
+	w.Header().Set("Content-Type", "application/json")
 	err = json.NewEncoder(w).Encode(mappedGroups)
 	if err != nil {
 		http.Error(w, "Failed to encode command groups", http.StatusInternalServerError)
 	}
-
-	w.Header().Set("Content-Type", "application/json")
 }
 
 func (s *ThirdPartyIntegrationsServer) handleRunCommandGroup(w http.ResponseWriter, r *http.Request) {
@@ -134,9 +127,6 @@ func (s *ThirdPartyIntegrationsServer) handleRunCommandGroup(w http.ResponseWrit
 
 	// Extract command group ID from URL
 	id := r.PathValue("id")
-	if id == "" {
-		http.Error(w, "Command Group ID is required", http.StatusBadRequest)
-	}
 
 	err := s.useCases.RunCommandGroup.Execute(id)
 	if err != nil {
@@ -153,9 +143,6 @@ func (s *ThirdPartyIntegrationsServer) handleStopCommandGroup(w http.ResponseWri
 
 	// Extract command group ID from URL
 	id := r.PathValue("id")
-	if id == "" {
-		http.Error(w, "Command Group ID is required", http.StatusBadRequest)
-	}
 
 	err := s.useCases.StopCommandGroup.Execute(id)
 	if err != nil {

--- a/cmd/gomander/thirdpartyserver/handlers.go
+++ b/cmd/gomander/thirdpartyserver/handlers.go
@@ -18,7 +18,7 @@ func (s *ThirdPartyIntegrationsServer) handleDiscovery(w http.ResponseWriter, r 
 	w.WriteHeader(http.StatusOK)
 	_, err := w.Write([]byte(`{"app": "Gomander"}`))
 	if err != nil {
-		println("Error writing response:", err.Error())
+		http.Error(w, "Failed to write response", http.StatusInternalServerError)
 	}
 }
 

--- a/cmd/gomander/thirdpartyserver/openapi.yaml
+++ b/cmd/gomander/thirdpartyserver/openapi.yaml
@@ -51,7 +51,7 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  /command/run/{id}:
+  /commands/{id}/run:
     post:
       summary: Run a command
       description: Executes a command by its ID
@@ -73,7 +73,7 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  /command/stop/{id}:
+  /commands/{id}/stop:
     post:
       summary: Stop a command
       description: Stops a running command by its ID
@@ -114,7 +114,7 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  /command-group/run/{id}:
+  /command-groups/{id}/run:
     post:
       summary: Run a command group
       description: Executes all commands in a command group by its ID
@@ -136,7 +136,7 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  /command-group/stop/{id}:
+  /command-groups/{id}/stop:
     post:
       summary: Stop a command group
       description: Stops all running commands in a command group by its ID

--- a/cmd/gomander/thirdpartyserver/openapi.yaml
+++ b/cmd/gomander/thirdpartyserver/openapi.yaml
@@ -1,8 +1,14 @@
-openapi: 3.0.3
+openapi: 3.1.1
 info:
   title: Gomander Third-Party Integration API
+  license:
+    name: GNU General Public License v3.0
+    identifier: GPL-3.0
+    url: 'https://www.gnu.org/licenses/gpl-3.0.html'
   description: API for interacting with Gomander commands and command groups
   version: 1.0.0
+
+security: []
 
 servers:
   - url: 'http://localhost:{port}'

--- a/cmd/gomander/thirdpartyserver/openapi.yaml
+++ b/cmd/gomander/thirdpartyserver/openapi.yaml
@@ -1,0 +1,232 @@
+openapi: 3.0.3
+info:
+  title: Gomander Third-Party Integration API
+  description: API for interacting with Gomander commands and command groups
+  version: 1.0.0
+
+servers:
+  - url: 'http://localhost:{port}'
+    description: Local Gomander server
+    variables:
+      port:
+        default: '9001'
+        description: The port ranges from 9001 to 9100, first available port will be used
+
+paths:
+  /discovery:
+    get:
+      summary: Discover Gomander API
+      description: Returns basic information about the Gomander API
+      operationId: getDiscovery
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  app:
+                    type: string
+                    example: "Gomander"
+        '405':
+          $ref: '#/components/responses/MethodNotAllowed'
+
+  /commands:
+    get:
+      summary: Get all commands
+      description: Returns a list of all commands with their status (running/stopped)
+      operationId: getCommands
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CommandWithStatus'
+        '405':
+          $ref: '#/components/responses/MethodNotAllowed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /command/run/{id}:
+    post:
+      summary: Run a command
+      description: Executes a command by its ID
+      operationId: runCommand
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Command ID
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Command started successfully
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '405':
+          $ref: '#/components/responses/MethodNotAllowed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /command/stop/{id}:
+    post:
+      summary: Stop a command
+      description: Stops a running command by its ID
+      operationId: stopCommand
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Command ID
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Command stopped successfully
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '405':
+          $ref: '#/components/responses/MethodNotAllowed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /command-groups:
+    get:
+      summary: Get all command groups
+      description: Returns a list of all command groups with information about running commands
+      operationId: getCommandGroups
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CommandGroupWithStatus'
+        '405':
+          $ref: '#/components/responses/MethodNotAllowed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /command-group/run/{id}:
+    post:
+      summary: Run a command group
+      description: Executes all commands in a command group by its ID
+      operationId: runCommandGroup
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Command Group ID
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Command group started successfully
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '405':
+          $ref: '#/components/responses/MethodNotAllowed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /command-group/stop/{id}:
+    post:
+      summary: Stop a command group
+      description: Stops all running commands in a command group by its ID
+      operationId: stopCommandGroup
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Command Group ID
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Command group stopped successfully
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '405':
+          $ref: '#/components/responses/MethodNotAllowed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+components:
+  schemas:
+    CommandWithStatus:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique identifier of the command
+          example: "cmd-1"
+        name:
+          type: string
+          description: Display name of the command
+          example: "Start Backend Server"
+        status:
+          type: string
+          enum: [running, stopped]
+          description: Current status of the command
+          example: "running"
+      required:
+        - id
+        - name
+        - status
+
+    CommandGroupWithStatus:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique identifier of the command group
+          example: "group-1"
+        name:
+          type: string
+          description: Display name of the command group
+          example: "Full Stack Development"
+        commands:
+          type: integer
+          description: Total number of commands in the group
+          example: 3
+        runningCommands:
+          type: integer
+          description: Number of currently running commands in the group
+          example: 1
+      required:
+        - id
+        - name
+        - commands
+        - runningCommands
+
+  responses:
+    BadRequest:
+      description: Bad request - missing or invalid parameters
+      content:
+        text/plain:
+          schema:
+            type: string
+            example: "Command ID is required"
+
+    MethodNotAllowed:
+      description: Method not allowed
+      content:
+        text/plain:
+          schema:
+            type: string
+            example: "Method not allowed"
+
+    InternalServerError:
+      description: Internal server error
+      content:
+        text/plain:
+          schema:
+            type: string
+            example: "Failed to get commands"

--- a/cmd/gomander/thirdpartyserver/thirdpartyhttpserver.go
+++ b/cmd/gomander/thirdpartyserver/thirdpartyhttpserver.go
@@ -1,0 +1,94 @@
+package thirdpartyserver
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+
+	"gomander/internal/app"
+)
+
+var StartPort = 9001
+var EndPort = 9100
+
+type ThirdPartyIntegrationsServer struct {
+	useCases app.UseCases
+	mu       sync.RWMutex
+	Server   *http.Server
+}
+
+func NewThirdPartyIntegrationsServer(useCases app.UseCases) *ThirdPartyIntegrationsServer {
+	return &ThirdPartyIntegrationsServer{
+		useCases: useCases,
+	}
+}
+
+func (s *ThirdPartyIntegrationsServer) RegisterHandlers() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	port, err := findAvailablePort()
+	if err != nil {
+		return err
+	}
+
+	if s.Server != nil {
+		return nil // Server is already running
+	}
+
+	mux := http.NewServeMux()
+
+	// Discovery endpoint
+	mux.HandleFunc("/discovery", s.handleDiscovery)
+
+	// Commands and Command Groups endpoints
+	mux.HandleFunc("/commands", s.handleGetCommands)
+	mux.HandleFunc("/command/run/{id}", s.handleRunCommand)
+	mux.HandleFunc("/command/stop/{id}", s.handleStopCommand)
+	//
+	mux.HandleFunc("/command-groups", s.handleGetCommandGroups)
+	mux.HandleFunc("/command-group/run/{id}", s.handleRunCommandGroup)
+	mux.HandleFunc("/command-group/stop/{id}", s.handleStopCommandGroup)
+
+	s.Server = &http.Server{
+		Addr:    fmt.Sprintf(":%d", port),
+		Handler: mux,
+	}
+
+	return nil
+}
+
+func (s *ThirdPartyIntegrationsServer) Start() {
+	go func() {
+		if err := s.Server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			// Handle error (log it, etc.)
+			println(err.Error())
+		}
+	}()
+}
+
+func (s *ThirdPartyIntegrationsServer) Stop() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.Server == nil {
+		return nil // Server is not running
+	}
+
+	err := s.Server.Close()
+	s.Server = nil
+	return err
+}
+
+func findAvailablePort() (int, error) {
+	for port := StartPort; port <= EndPort; port++ {
+		ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+		if err != nil {
+			continue // Port is in use
+		}
+		_ = ln.Close() // Close the listener immediately
+		return port, nil
+	}
+	return 0, fmt.Errorf("no available ports found in range %d-%d", StartPort, EndPort)
+}

--- a/cmd/gomander/thirdpartyserver/thirdpartyhttpserver.go
+++ b/cmd/gomander/thirdpartyserver/thirdpartyhttpserver.go
@@ -44,12 +44,12 @@ func (s *ThirdPartyIntegrationsServer) RegisterHandlers() error {
 
 	// Commands and Command Groups endpoints
 	mux.HandleFunc("/commands", s.handleGetCommands)
-	mux.HandleFunc("/command/run/{id}", s.handleRunCommand)
-	mux.HandleFunc("/command/stop/{id}", s.handleStopCommand)
+	mux.HandleFunc("/commands/{id}/run", s.handleRunCommand)
+	mux.HandleFunc("/commands/{id}/stop", s.handleStopCommand)
 	//
 	mux.HandleFunc("/command-groups", s.handleGetCommandGroups)
-	mux.HandleFunc("/command-group/run/{id}", s.handleRunCommandGroup)
-	mux.HandleFunc("/command-group/stop/{id}", s.handleStopCommandGroup)
+	mux.HandleFunc("/command-groups/{id}/run", s.handleRunCommandGroup)
+	mux.HandleFunc("/command-groups/{id}/stop", s.handleStopCommandGroup)
 
 	s.Server = &http.Server{
 		Addr:    fmt.Sprintf(":%d", port),

--- a/cmd/gomander/thirdpartyserver/thirdpartyhttpserver_test.go
+++ b/cmd/gomander/thirdpartyserver/thirdpartyhttpserver_test.go
@@ -1,0 +1,643 @@
+package thirdpartyserver_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"gomander/cmd/gomander/thirdpartyserver"
+	"gomander/internal/app"
+	commandusecasestest "gomander/internal/command/application/usecases/test"
+	commanddomain "gomander/internal/command/domain"
+	commandgroupusecasestest "gomander/internal/commandgroup/application/usecases/test"
+	commandgroupdomain "gomander/internal/commandgroup/domain"
+)
+
+func TestNewThirdPartyIntegrationsServer_DiscoveryHandler(t *testing.T) {
+	t.Run("GET /discovery should return discovery info", func(t *testing.T) {
+		// Arrange
+		server := thirdpartyserver.NewThirdPartyIntegrationsServer(app.UseCases{})
+		err := server.RegisterHandlers()
+		assert.NoError(t, err)
+
+		testServer := httptest.NewServer(server.Server.Handler)
+		defer testServer.Close()
+
+		// Act
+		resp, err := http.Get(testServer.URL + "/discovery")
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Assert
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{"app": "Gomander"}`, string(body))
+	})
+	t.Run("POST /discovery should return 405 Method Not Allowed", func(t *testing.T) {
+		// Arrange
+		server := thirdpartyserver.NewThirdPartyIntegrationsServer(app.UseCases{})
+		err := server.RegisterHandlers()
+		assert.NoError(t, err)
+
+		testServer := httptest.NewServer(server.Server.Handler)
+		defer testServer.Close()
+
+		// Act
+		resp, err := http.Post(testServer.URL+"/discovery", "application/json", nil)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Assert
+		assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+	})
+}
+
+func TestNewThirdPartyIntegrationsServer_GetCommandsHandler(t *testing.T) {
+	t.Run("GET /commands should return commands list with status", func(t *testing.T) {
+		// Arrange
+		mockGetCommands := new(commandusecasestest.MockGetCommands)
+		mockGetRunningCommandIds := new(commandusecasestest.MockGetRunningCommandIds)
+
+		commands := []commanddomain.Command{
+			{
+				Id:      "cmd-1",
+				Name:    "Command 1",
+				Command: "echo 1",
+			},
+			{
+				Id:      "cmd-2",
+				Name:    "Command 2",
+				Command: "echo 2",
+			},
+		}
+
+		runningCommandIds := []string{"cmd-1"}
+
+		mockGetCommands.On("Execute").Return(commands, nil)
+		mockGetRunningCommandIds.On("Execute").Return(runningCommandIds)
+
+		useCases := app.UseCases{
+			GetCommands:          mockGetCommands,
+			GetRunningCommandIds: mockGetRunningCommandIds,
+		}
+
+		server := thirdpartyserver.NewThirdPartyIntegrationsServer(useCases)
+		err := server.RegisterHandlers()
+		assert.NoError(t, err)
+
+		testServer := httptest.NewServer(server.Server.Handler)
+		defer testServer.Close()
+
+		// Act
+		resp, err := http.Get(testServer.URL + "/commands")
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Assert
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var result []map[string]interface{}
+		body, err := io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		err = json.Unmarshal(body, &result)
+		assert.NoError(t, err)
+
+		assert.Equal(t, result, []map[string]interface{}{
+			{
+				"id":      "cmd-1",
+				"name":    "Command 1",
+				"command": "echo 1",
+				"status":  "running",
+			},
+			{
+				"id":      "cmd-2",
+				"name":    "Command 2",
+				"command": "echo 2",
+				"status":  "stopped",
+			},
+		})
+
+		mock.AssertExpectationsForObjects(t, mockGetRunningCommandIds, mockGetCommands)
+	})
+
+	t.Run("POST /commands should return 405 Method Not Allowed", func(t *testing.T) {
+		// Arrange
+		server := thirdpartyserver.NewThirdPartyIntegrationsServer(app.UseCases{})
+		err := server.RegisterHandlers()
+		assert.NoError(t, err)
+
+		testServer := httptest.NewServer(server.Server.Handler)
+		defer testServer.Close()
+
+		// Act
+		resp, err := http.Post(testServer.URL+"/commands", "application/json", nil)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Assert
+		assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+	})
+
+	t.Run("Should return 500 when GetCommands returns error", func(t *testing.T) {
+		// Arrange
+		mockGetCommands := new(commandusecasestest.MockGetCommands)
+		expectedError := fmt.Errorf("database error")
+
+		mockGetCommands.On("Execute").Return([]commanddomain.Command{}, expectedError)
+
+		useCases := app.UseCases{
+			GetCommands: mockGetCommands,
+		}
+
+		server := thirdpartyserver.NewThirdPartyIntegrationsServer(useCases)
+		err := server.RegisterHandlers()
+		assert.NoError(t, err)
+
+		testServer := httptest.NewServer(server.Server.Handler)
+		defer testServer.Close()
+
+		// Act
+		resp, err := http.Get(testServer.URL + "/commands")
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Assert
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		mockGetCommands.AssertExpectations(t)
+	})
+}
+
+// Test Run Command Handler
+func TestNewThirdPartyIntegrationsServer_RunCommandHandler(t *testing.T) {
+	t.Run("POST /command/run/{id} should run the command", func(t *testing.T) {
+		// Arrange
+		mockRunCommand := new(commandusecasestest.MockRunCommands)
+		commandId := "cmd-1"
+
+		mockRunCommand.On("Execute", commandId).Return(nil)
+
+		useCases := app.UseCases{
+			RunCommand: mockRunCommand,
+		}
+
+		server := thirdpartyserver.NewThirdPartyIntegrationsServer(useCases)
+		err := server.RegisterHandlers()
+		assert.NoError(t, err)
+
+		testServer := httptest.NewServer(server.Server.Handler)
+		defer testServer.Close()
+
+		// Act
+		resp, err := http.Post(testServer.URL+"/command/run/"+commandId, "application/json", nil)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Assert
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		mock.AssertExpectationsForObjects(t, mockRunCommand)
+	})
+
+	t.Run("GET /command/run/{id} should return 405 Method Not Allowed", func(t *testing.T) {
+		// Arrange
+		server := thirdpartyserver.NewThirdPartyIntegrationsServer(app.UseCases{})
+		err := server.RegisterHandlers()
+		assert.NoError(t, err)
+
+		testServer := httptest.NewServer(server.Server.Handler)
+		defer testServer.Close()
+
+		// Act
+		resp, err := http.Get(testServer.URL + "/command/run/cmd-1")
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Assert
+		assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+	})
+
+	t.Run("Should return 500 when RunCommand returns error", func(t *testing.T) {
+		// Arrange
+		mockRunCommand := new(commandusecasestest.MockRunCommands)
+		commandId := "cmd-1"
+		expectedError := fmt.Errorf("failed to run command")
+
+		mockRunCommand.On("Execute", commandId).Return(expectedError)
+
+		useCases := app.UseCases{
+			RunCommand: mockRunCommand,
+		}
+
+		server := thirdpartyserver.NewThirdPartyIntegrationsServer(useCases)
+		err := server.RegisterHandlers()
+		assert.NoError(t, err)
+
+		testServer := httptest.NewServer(server.Server.Handler)
+		defer testServer.Close()
+
+		// Act
+		resp, err := http.Post(testServer.URL+"/command/run/"+commandId, "application/json", nil)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Assert
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		mockRunCommand.AssertExpectations(t)
+	})
+}
+
+// Test Stop Command Handler
+func TestNewThirdPartyIntegrationsServer_StopCommandHandler(t *testing.T) {
+	t.Run("POST /command/stop/{id} should stop the command", func(t *testing.T) {
+		// Arrange
+		mockStopCommand := new(commandusecasestest.MockStopCommand)
+		commandId := "cmd-1"
+
+		mockStopCommand.On("Execute", commandId).Return(nil)
+
+		useCases := app.UseCases{
+			StopCommand: mockStopCommand,
+		}
+
+		server := thirdpartyserver.NewThirdPartyIntegrationsServer(useCases)
+		err := server.RegisterHandlers()
+		assert.NoError(t, err)
+
+		testServer := httptest.NewServer(server.Server.Handler)
+		defer testServer.Close()
+
+		// Act
+		resp, err := http.Post(testServer.URL+"/command/stop/"+commandId, "application/json", nil)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Assert
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		mock.AssertExpectationsForObjects(t, mockStopCommand)
+	})
+
+	t.Run("GET /command/stop/{id} should return 405 Method Not Allowed", func(t *testing.T) {
+		// Arrange
+		server := thirdpartyserver.NewThirdPartyIntegrationsServer(app.UseCases{})
+		err := server.RegisterHandlers()
+		assert.NoError(t, err)
+
+		testServer := httptest.NewServer(server.Server.Handler)
+		defer testServer.Close()
+
+		// Act
+		resp, err := http.Get(testServer.URL + "/command/stop/cmd-1")
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Assert
+		assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+	})
+
+	t.Run("Should return 500 when StopCommand returns error", func(t *testing.T) {
+		// Arrange
+		mockStopCommand := new(commandusecasestest.MockStopCommand)
+		commandId := "cmd-1"
+		expectedError := fmt.Errorf("failed to stop command")
+
+		mockStopCommand.On("Execute", commandId).Return(expectedError)
+
+		useCases := app.UseCases{
+			StopCommand: mockStopCommand,
+		}
+
+		server := thirdpartyserver.NewThirdPartyIntegrationsServer(useCases)
+		err := server.RegisterHandlers()
+		assert.NoError(t, err)
+
+		testServer := httptest.NewServer(server.Server.Handler)
+		defer testServer.Close()
+
+		// Act
+		resp, err := http.Post(testServer.URL+"/command/stop/"+commandId, "application/json", nil)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Assert
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		mockStopCommand.AssertExpectations(t)
+	})
+}
+
+// Test Run Command Group Handler
+func TestNewThirdPartyIntegrationsServer_RunCommandGroupHandler(t *testing.T) {
+	t.Run("POST /command-group/run/{id} should run the command group", func(t *testing.T) {
+		// Arrange
+		mockRunCommandGroup := new(commandgroupusecasestest.MockRunCommandGroup)
+		groupId := "group-1"
+
+		mockRunCommandGroup.On("Execute", groupId).Return(nil)
+
+		useCases := app.UseCases{
+			RunCommandGroup: mockRunCommandGroup,
+		}
+
+		server := thirdpartyserver.NewThirdPartyIntegrationsServer(useCases)
+		err := server.RegisterHandlers()
+		assert.NoError(t, err)
+
+		testServer := httptest.NewServer(server.Server.Handler)
+		defer testServer.Close()
+
+		// Act
+		resp, err := http.Post(testServer.URL+"/command-group/run/"+groupId, "application/json", nil)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Assert
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		mock.AssertExpectationsForObjects(t, mockRunCommandGroup)
+	})
+
+	t.Run("GET /command-group/run/{id} should return 405 Method Not Allowed", func(t *testing.T) {
+		// Arrange
+		server := thirdpartyserver.NewThirdPartyIntegrationsServer(app.UseCases{})
+		err := server.RegisterHandlers()
+		assert.NoError(t, err)
+
+		testServer := httptest.NewServer(server.Server.Handler)
+		defer testServer.Close()
+
+		// Act
+		resp, err := http.Get(testServer.URL + "/command-group/run/group-1")
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Assert
+		assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+	})
+
+	t.Run("Should return 500 when RunCommandGroup returns error", func(t *testing.T) {
+		// Arrange
+		mockRunCommandGroup := new(commandgroupusecasestest.MockRunCommandGroup)
+		groupId := "group-1"
+		expectedError := fmt.Errorf("failed to run command group")
+
+		mockRunCommandGroup.On("Execute", groupId).Return(expectedError)
+
+		useCases := app.UseCases{
+			RunCommandGroup: mockRunCommandGroup,
+		}
+
+		server := thirdpartyserver.NewThirdPartyIntegrationsServer(useCases)
+		err := server.RegisterHandlers()
+		assert.NoError(t, err)
+
+		testServer := httptest.NewServer(server.Server.Handler)
+		defer testServer.Close()
+
+		// Act
+		resp, err := http.Post(testServer.URL+"/command-group/run/"+groupId, "application/json", nil)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Assert
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		mockRunCommandGroup.AssertExpectations(t)
+	})
+}
+
+// Test Stop Command Group Handler
+func TestNewThirdPartyIntegrationsServer_StopCommandGroupHandler(t *testing.T) {
+	t.Run("POST /command-group/stop/{id} should stop the command group", func(t *testing.T) {
+		// Arrange
+		mockStopCommandGroup := new(commandgroupusecasestest.MockStopCommandGroup)
+		groupId := "group-1"
+
+		mockStopCommandGroup.On("Execute", groupId).Return(nil)
+
+		useCases := app.UseCases{
+			StopCommandGroup: mockStopCommandGroup,
+		}
+
+		server := thirdpartyserver.NewThirdPartyIntegrationsServer(useCases)
+		err := server.RegisterHandlers()
+		assert.NoError(t, err)
+
+		testServer := httptest.NewServer(server.Server.Handler)
+		defer testServer.Close()
+
+		// Act
+		resp, err := http.Post(testServer.URL+"/command-group/stop/"+groupId, "application/json", nil)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Assert
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		mock.AssertExpectationsForObjects(t, mockStopCommandGroup)
+	})
+
+	t.Run("GET /command-group/stop/{id} should return 405 Method Not Allowed", func(t *testing.T) {
+		// Arrange
+		server := thirdpartyserver.NewThirdPartyIntegrationsServer(app.UseCases{})
+		err := server.RegisterHandlers()
+		assert.NoError(t, err)
+
+		testServer := httptest.NewServer(server.Server.Handler)
+		defer testServer.Close()
+
+		// Act
+		resp, err := http.Get(testServer.URL + "/command-group/stop/group-1")
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Assert
+		assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+	})
+
+	t.Run("Should return 500 when StopCommandGroup returns error", func(t *testing.T) {
+		// Arrange
+		mockStopCommandGroup := new(commandgroupusecasestest.MockStopCommandGroup)
+		groupId := "group-1"
+		expectedError := fmt.Errorf("failed to stop command group")
+
+		mockStopCommandGroup.On("Execute", groupId).Return(expectedError)
+
+		useCases := app.UseCases{
+			StopCommandGroup: mockStopCommandGroup,
+		}
+
+		server := thirdpartyserver.NewThirdPartyIntegrationsServer(useCases)
+		err := server.RegisterHandlers()
+		assert.NoError(t, err)
+
+		testServer := httptest.NewServer(server.Server.Handler)
+		defer testServer.Close()
+
+		// Act
+		resp, err := http.Post(testServer.URL+"/command-group/stop/"+groupId, "application/json", nil)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Assert
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		mockStopCommandGroup.AssertExpectations(t)
+	})
+}
+
+// Test Get Command Groups Handler
+func TestNewThirdPartyIntegrationsServer_GetCommandGroupsHandler(t *testing.T) {
+	t.Run("GET /command-groups should return command groups list with running commands info", func(t *testing.T) {
+		// Arrange
+		mockGetCommandGroups := new(commandgroupusecasestest.MockGetCommandGroups)
+		mockGetRunningCommandIds := new(commandusecasestest.MockGetRunningCommandIds)
+
+		cmd1 := commanddomain.Command{Id: "cmd-1", Name: "Command 1", Command: "echo 1"}
+		cmd2 := commanddomain.Command{Id: "cmd-2", Name: "Command 2", Command: "echo 2"}
+		cmd3 := commanddomain.Command{Id: "cmd-3", Name: "Command 3", Command: "echo 3"}
+
+		groups := []commandgroupdomain.CommandGroup{
+			{
+				Id:       "group-1",
+				Name:     "Group 1",
+				Commands: []commanddomain.Command{cmd1, cmd2},
+			},
+			{
+				Id:       "group-2",
+				Name:     "Group 2",
+				Commands: []commanddomain.Command{cmd2, cmd3},
+			},
+		}
+
+		runningCommandIds := []string{"cmd-1", "cmd-3"}
+
+		mockGetCommandGroups.On("Execute").Return(groups, nil)
+		mockGetRunningCommandIds.On("Execute").Return(runningCommandIds)
+
+		useCases := app.UseCases{
+			GetCommandGroups:     mockGetCommandGroups,
+			GetRunningCommandIds: mockGetRunningCommandIds,
+		}
+
+		server := thirdpartyserver.NewThirdPartyIntegrationsServer(useCases)
+		err := server.RegisterHandlers()
+		assert.NoError(t, err)
+
+		testServer := httptest.NewServer(server.Server.Handler)
+		defer testServer.Close()
+
+		// Act
+		resp, err := http.Get(testServer.URL + "/command-groups")
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Assert
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var result []map[string]interface{}
+		body, err := io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		err = json.Unmarshal(body, &result)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 2, len(result))
+
+		// First group should have 2 commands with 1 running
+		assert.Equal(t, "group-1", result[0]["id"])
+		assert.Equal(t, "Group 1", result[0]["name"])
+		assert.Equal(t, float64(2), result[0]["commands"])
+		assert.Equal(t, float64(1), result[0]["runningCommands"])
+
+		// Second group should have 2 commands with 1 running
+		assert.Equal(t, "group-2", result[1]["id"])
+		assert.Equal(t, "Group 2", result[1]["name"])
+		assert.Equal(t, float64(2), result[1]["commands"])
+		assert.Equal(t, float64(1), result[1]["runningCommands"])
+
+		mock.AssertExpectationsForObjects(t, mockGetCommandGroups, mockGetRunningCommandIds)
+	})
+
+	t.Run("POST /command-groups should return 405 Method Not Allowed", func(t *testing.T) {
+		// Arrange
+		server := thirdpartyserver.NewThirdPartyIntegrationsServer(app.UseCases{})
+		err := server.RegisterHandlers()
+		assert.NoError(t, err)
+
+		testServer := httptest.NewServer(server.Server.Handler)
+		defer testServer.Close()
+
+		// Act
+		resp, err := http.Post(testServer.URL+"/command-groups", "application/json", nil)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Assert
+		assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+	})
+
+	t.Run("Should return 500 when GetCommandGroups returns error", func(t *testing.T) {
+		// Arrange
+		mockGetCommandGroups := new(commandgroupusecasestest.MockGetCommandGroups)
+		expectedError := fmt.Errorf("failed to get command groups")
+
+		mockGetCommandGroups.On("Execute").Return([]commandgroupdomain.CommandGroup{}, expectedError)
+
+		useCases := app.UseCases{
+			GetCommandGroups: mockGetCommandGroups,
+		}
+
+		server := thirdpartyserver.NewThirdPartyIntegrationsServer(useCases)
+		err := server.RegisterHandlers()
+		assert.NoError(t, err)
+
+		testServer := httptest.NewServer(server.Server.Handler)
+		defer testServer.Close()
+
+		// Act
+		resp, err := http.Get(testServer.URL + "/command-groups")
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Assert
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		mockGetCommandGroups.AssertExpectations(t)
+	})
+}
+
+func TestThirdPartyIntegrationsServer_StartAndStop(t *testing.T) {
+	t.Run("Should start and stop server without errors", func(t *testing.T) {
+		// Arrange
+		server := thirdpartyserver.NewThirdPartyIntegrationsServer(app.UseCases{})
+		err := server.RegisterHandlers()
+		assert.NoError(t, err)
+
+		// Act - Start the server
+		server.Start()
+
+		// Wait a bit for server to fully start
+		time.Sleep(100 * time.Millisecond)
+
+		// Assert - Check if server is running by making a request to the discovery endpoint
+		var resp *http.Response
+		var requestErr error
+
+		assert.Eventually(t, func() bool {
+			serverAddr := server.Server.Addr
+			resp, requestErr = http.Get(fmt.Sprintf("http://%s/discovery", serverAddr))
+			return requestErr == nil
+		}, 500*time.Millisecond, 100*time.Millisecond, "Server should respond to /discovery requests")
+
+		assert.NoError(t, requestErr)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		resp.Body.Close()
+
+		// Act - Stop the server
+		err = server.Stop()
+
+		// Assert - Server stopped without error
+		assert.NoError(t, err)
+	})
+}

--- a/cmd/gomander/thirdpartyserver/thirdpartyhttpserver_test.go
+++ b/cmd/gomander/thirdpartyserver/thirdpartyhttpserver_test.go
@@ -174,7 +174,7 @@ func TestNewThirdPartyIntegrationsServer_GetCommandsHandler(t *testing.T) {
 
 // Test Run Command Handler
 func TestNewThirdPartyIntegrationsServer_RunCommandHandler(t *testing.T) {
-	t.Run("POST /command/run/{id} should run the command", func(t *testing.T) {
+	t.Run("POST /commands/{id}/run should run the command", func(t *testing.T) {
 		// Arrange
 		mockRunCommand := new(commandusecasestest.MockRunCommands)
 		commandId := "cmd-1"
@@ -193,7 +193,7 @@ func TestNewThirdPartyIntegrationsServer_RunCommandHandler(t *testing.T) {
 		defer testServer.Close()
 
 		// Act
-		resp, err := http.Post(testServer.URL+"/command/run/"+commandId, "application/json", nil)
+		resp, err := http.Post(testServer.URL+"/commands/"+commandId+"/run", "application/json", nil)
 		assert.NoError(t, err)
 		defer resp.Body.Close()
 
@@ -202,7 +202,7 @@ func TestNewThirdPartyIntegrationsServer_RunCommandHandler(t *testing.T) {
 		mock.AssertExpectationsForObjects(t, mockRunCommand)
 	})
 
-	t.Run("GET /command/run/{id} should return 405 Method Not Allowed", func(t *testing.T) {
+	t.Run("GET /commands/{id}/run should return 405 Method Not Allowed", func(t *testing.T) {
 		// Arrange
 		server := thirdpartyserver.NewThirdPartyIntegrationsServer(app.UseCases{})
 		err := server.RegisterHandlers()
@@ -212,7 +212,7 @@ func TestNewThirdPartyIntegrationsServer_RunCommandHandler(t *testing.T) {
 		defer testServer.Close()
 
 		// Act
-		resp, err := http.Get(testServer.URL + "/command/run/cmd-1")
+		resp, err := http.Get(testServer.URL + "/commands/cmd-1/run")
 		assert.NoError(t, err)
 		defer resp.Body.Close()
 
@@ -240,7 +240,7 @@ func TestNewThirdPartyIntegrationsServer_RunCommandHandler(t *testing.T) {
 		defer testServer.Close()
 
 		// Act
-		resp, err := http.Post(testServer.URL+"/command/run/"+commandId, "application/json", nil)
+		resp, err := http.Post(testServer.URL+"/commands/"+commandId+"/run", "application/json", nil)
 		assert.NoError(t, err)
 		defer resp.Body.Close()
 
@@ -252,7 +252,7 @@ func TestNewThirdPartyIntegrationsServer_RunCommandHandler(t *testing.T) {
 
 // Test Stop Command Handler
 func TestNewThirdPartyIntegrationsServer_StopCommandHandler(t *testing.T) {
-	t.Run("POST /command/stop/{id} should stop the command", func(t *testing.T) {
+	t.Run("POST /commands/{id}/stop should stop the command", func(t *testing.T) {
 		// Arrange
 		mockStopCommand := new(commandusecasestest.MockStopCommand)
 		commandId := "cmd-1"
@@ -271,7 +271,7 @@ func TestNewThirdPartyIntegrationsServer_StopCommandHandler(t *testing.T) {
 		defer testServer.Close()
 
 		// Act
-		resp, err := http.Post(testServer.URL+"/command/stop/"+commandId, "application/json", nil)
+		resp, err := http.Post(testServer.URL+"/commands/"+commandId+"/stop", "application/json", nil)
 		assert.NoError(t, err)
 		defer resp.Body.Close()
 
@@ -280,7 +280,7 @@ func TestNewThirdPartyIntegrationsServer_StopCommandHandler(t *testing.T) {
 		mock.AssertExpectationsForObjects(t, mockStopCommand)
 	})
 
-	t.Run("GET /command/stop/{id} should return 405 Method Not Allowed", func(t *testing.T) {
+	t.Run("GET /commands/{id}/stop should return 405 Method Not Allowed", func(t *testing.T) {
 		// Arrange
 		server := thirdpartyserver.NewThirdPartyIntegrationsServer(app.UseCases{})
 		err := server.RegisterHandlers()
@@ -290,7 +290,7 @@ func TestNewThirdPartyIntegrationsServer_StopCommandHandler(t *testing.T) {
 		defer testServer.Close()
 
 		// Act
-		resp, err := http.Get(testServer.URL + "/command/stop/cmd-1")
+		resp, err := http.Get(testServer.URL + "/commands/cmd-1/stop")
 		assert.NoError(t, err)
 		defer resp.Body.Close()
 
@@ -318,7 +318,7 @@ func TestNewThirdPartyIntegrationsServer_StopCommandHandler(t *testing.T) {
 		defer testServer.Close()
 
 		// Act
-		resp, err := http.Post(testServer.URL+"/command/stop/"+commandId, "application/json", nil)
+		resp, err := http.Post(testServer.URL+"/commands/"+commandId+"/stop", "application/json", nil)
 		assert.NoError(t, err)
 		defer resp.Body.Close()
 
@@ -330,7 +330,7 @@ func TestNewThirdPartyIntegrationsServer_StopCommandHandler(t *testing.T) {
 
 // Test Run Command Group Handler
 func TestNewThirdPartyIntegrationsServer_RunCommandGroupHandler(t *testing.T) {
-	t.Run("POST /command-group/run/{id} should run the command group", func(t *testing.T) {
+	t.Run("POST /command-groups/{id}/run should run the command group", func(t *testing.T) {
 		// Arrange
 		mockRunCommandGroup := new(commandgroupusecasestest.MockRunCommandGroup)
 		groupId := "group-1"
@@ -349,7 +349,7 @@ func TestNewThirdPartyIntegrationsServer_RunCommandGroupHandler(t *testing.T) {
 		defer testServer.Close()
 
 		// Act
-		resp, err := http.Post(testServer.URL+"/command-group/run/"+groupId, "application/json", nil)
+		resp, err := http.Post(testServer.URL+"/command-groups/"+groupId+"/run", "application/json", nil)
 		assert.NoError(t, err)
 		defer resp.Body.Close()
 
@@ -358,7 +358,7 @@ func TestNewThirdPartyIntegrationsServer_RunCommandGroupHandler(t *testing.T) {
 		mock.AssertExpectationsForObjects(t, mockRunCommandGroup)
 	})
 
-	t.Run("GET /command-group/run/{id} should return 405 Method Not Allowed", func(t *testing.T) {
+	t.Run("GET /command-groups/{id}/run should return 405 Method Not Allowed", func(t *testing.T) {
 		// Arrange
 		server := thirdpartyserver.NewThirdPartyIntegrationsServer(app.UseCases{})
 		err := server.RegisterHandlers()
@@ -368,7 +368,7 @@ func TestNewThirdPartyIntegrationsServer_RunCommandGroupHandler(t *testing.T) {
 		defer testServer.Close()
 
 		// Act
-		resp, err := http.Get(testServer.URL + "/command-group/run/group-1")
+		resp, err := http.Get(testServer.URL + "/command-groups/group-1/run")
 		assert.NoError(t, err)
 		defer resp.Body.Close()
 
@@ -396,7 +396,7 @@ func TestNewThirdPartyIntegrationsServer_RunCommandGroupHandler(t *testing.T) {
 		defer testServer.Close()
 
 		// Act
-		resp, err := http.Post(testServer.URL+"/command-group/run/"+groupId, "application/json", nil)
+		resp, err := http.Post(testServer.URL+"/command-groups/"+groupId+"/run", "application/json", nil)
 		assert.NoError(t, err)
 		defer resp.Body.Close()
 
@@ -408,7 +408,7 @@ func TestNewThirdPartyIntegrationsServer_RunCommandGroupHandler(t *testing.T) {
 
 // Test Stop Command Group Handler
 func TestNewThirdPartyIntegrationsServer_StopCommandGroupHandler(t *testing.T) {
-	t.Run("POST /command-group/stop/{id} should stop the command group", func(t *testing.T) {
+	t.Run("POST /command-groups/{id}/stop should stop the command group", func(t *testing.T) {
 		// Arrange
 		mockStopCommandGroup := new(commandgroupusecasestest.MockStopCommandGroup)
 		groupId := "group-1"
@@ -427,7 +427,7 @@ func TestNewThirdPartyIntegrationsServer_StopCommandGroupHandler(t *testing.T) {
 		defer testServer.Close()
 
 		// Act
-		resp, err := http.Post(testServer.URL+"/command-group/stop/"+groupId, "application/json", nil)
+		resp, err := http.Post(testServer.URL+"/command-groups/"+groupId+"/stop", "application/json", nil)
 		assert.NoError(t, err)
 		defer resp.Body.Close()
 
@@ -436,7 +436,7 @@ func TestNewThirdPartyIntegrationsServer_StopCommandGroupHandler(t *testing.T) {
 		mock.AssertExpectationsForObjects(t, mockStopCommandGroup)
 	})
 
-	t.Run("GET /command-group/stop/{id} should return 405 Method Not Allowed", func(t *testing.T) {
+	t.Run("GET /command-groups/{id}/stop should return 405 Method Not Allowed", func(t *testing.T) {
 		// Arrange
 		server := thirdpartyserver.NewThirdPartyIntegrationsServer(app.UseCases{})
 		err := server.RegisterHandlers()
@@ -446,7 +446,7 @@ func TestNewThirdPartyIntegrationsServer_StopCommandGroupHandler(t *testing.T) {
 		defer testServer.Close()
 
 		// Act
-		resp, err := http.Get(testServer.URL + "/command-group/stop/group-1")
+		resp, err := http.Get(testServer.URL + "/command-groups/group-1/stop")
 		assert.NoError(t, err)
 		defer resp.Body.Close()
 
@@ -474,7 +474,7 @@ func TestNewThirdPartyIntegrationsServer_StopCommandGroupHandler(t *testing.T) {
 		defer testServer.Close()
 
 		// Act
-		resp, err := http.Post(testServer.URL+"/command-group/stop/"+groupId, "application/json", nil)
+		resp, err := http.Post(testServer.URL+"/command-groups/"+groupId+"/stop", "application/json", nil)
 		assert.NoError(t, err)
 		defer resp.Body.Close()
 

--- a/cmd/gomander/thirdpartyserver/thirdpartyhttpserver_test.go
+++ b/cmd/gomander/thirdpartyserver/thirdpartyhttpserver_test.go
@@ -69,14 +69,12 @@ func TestNewThirdPartyIntegrationsServer_GetCommandsHandler(t *testing.T) {
 
 		commands := []commanddomain.Command{
 			{
-				Id:      "cmd-1",
-				Name:    "Command 1",
-				Command: "echo 1",
+				Id:   "cmd-1",
+				Name: "Command 1",
 			},
 			{
-				Id:      "cmd-2",
-				Name:    "Command 2",
-				Command: "echo 2",
+				Id:   "cmd-2",
+				Name: "Command 2",
 			},
 		}
 
@@ -113,16 +111,14 @@ func TestNewThirdPartyIntegrationsServer_GetCommandsHandler(t *testing.T) {
 
 		assert.Equal(t, result, []map[string]interface{}{
 			{
-				"id":      "cmd-1",
-				"name":    "Command 1",
-				"command": "echo 1",
-				"status":  "running",
+				"id":     "cmd-1",
+				"name":   "Command 1",
+				"status": "running",
 			},
 			{
-				"id":      "cmd-2",
-				"name":    "Command 2",
-				"command": "echo 2",
-				"status":  "stopped",
+				"id":     "cmd-2",
+				"name":   "Command 2",
+				"status": "stopped",
 			},
 		})
 
@@ -543,19 +539,21 @@ func TestNewThirdPartyIntegrationsServer_GetCommandGroupsHandler(t *testing.T) {
 		err = json.Unmarshal(body, &result)
 		assert.NoError(t, err)
 
-		assert.Equal(t, 2, len(result))
-
 		// First group should have 2 commands with 1 running
-		assert.Equal(t, "group-1", result[0]["id"])
-		assert.Equal(t, "Group 1", result[0]["name"])
-		assert.Equal(t, float64(2), result[0]["commands"])
-		assert.Equal(t, float64(1), result[0]["runningCommands"])
-
-		// Second group should have 2 commands with 1 running
-		assert.Equal(t, "group-2", result[1]["id"])
-		assert.Equal(t, "Group 2", result[1]["name"])
-		assert.Equal(t, float64(2), result[1]["commands"])
-		assert.Equal(t, float64(1), result[1]["runningCommands"])
+		assert.Equal(t, result, []map[string]interface{}{
+			{
+				"id":              "group-1",
+				"name":            "Group 1",
+				"commands":        float64(2),
+				"runningCommands": float64(1),
+			},
+			{
+				"id":              "group-2",
+				"name":            "Group 2",
+				"commands":        float64(2),
+				"runningCommands": float64(1),
+			},
+		})
 
 		mock.AssertExpectationsForObjects(t, mockGetCommandGroups, mockGetRunningCommandIds)
 	})

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,7 +10,8 @@ coverage:
 ignore:
   - "internal/testutils"
   - "migrations/*.go"
-  - "cmd/gomander"
+  - "cmd/gomander/controllers.go"
+  - "cmd/gomander/main.go"
   - "internal/app/app.go"
   - "**/*facade.go"
   - "**/*_testbuilder.go"

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -52,14 +52,15 @@ type UseCases struct {
 	RunCommandGroup               commandgroupusecases.RunCommandGroup
 	StopCommandGroup              commandgroupusecases.StopCommandGroup
 	// Commands
-	GetCommands      commandusecases.GetCommands
-	AddCommand       commandusecases.AddCommand
-	DuplicateCommand commandusecases.DuplicateCommand
-	RemoveCommand    commandusecases.RemoveCommand
-	EditCommand      commandusecases.EditCommand
-	ReorderCommands  commandusecases.ReorderCommands
-	RunCommand       commandusecases.RunCommand
-	StopCommand      commandusecases.StopCommand
+	GetCommands          commandusecases.GetCommands
+	AddCommand           commandusecases.AddCommand
+	DuplicateCommand     commandusecases.DuplicateCommand
+	RemoveCommand        commandusecases.RemoveCommand
+	EditCommand          commandusecases.EditCommand
+	ReorderCommands      commandusecases.ReorderCommands
+	RunCommand           commandusecases.RunCommand
+	StopCommand          commandusecases.StopCommand
+	GetRunningCommandIds commandusecases.GetRunningCommandIds
 }
 
 // App struct

--- a/internal/command/application/usecases/getrunningcommands.go
+++ b/internal/command/application/usecases/getrunningcommands.go
@@ -1,0 +1,21 @@
+package usecases
+
+import "gomander/internal/runner"
+
+type GetRunningCommandIds interface {
+	Execute() []string
+}
+
+type DefaultGetRunningCommandIds struct {
+	runner runner.Runner
+}
+
+func NewGetRunningCommandIds(runner runner.Runner) *DefaultGetRunningCommandIds {
+	return &DefaultGetRunningCommandIds{
+		runner: runner,
+	}
+}
+
+func (uc *DefaultGetRunningCommandIds) Execute() []string {
+	return uc.runner.GetRunningCommandIds()
+}

--- a/internal/command/application/usecases/getrunningcommands_test.go
+++ b/internal/command/application/usecases/getrunningcommands_test.go
@@ -1,0 +1,44 @@
+package usecases_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"gomander/internal/command/application/usecases"
+	"gomander/internal/runner/test"
+)
+
+func TestDefaultGetRunningCommandIds_Execute(t *testing.T) {
+	t.Run("Should return empty list when there are no running commands", func(t *testing.T) {
+		// Arrange
+		mockRunner := new(test.MockRunner)
+		sut := usecases.NewGetRunningCommandIds(mockRunner)
+
+		mockRunner.On("GetRunningCommandIds").Return([]string{})
+
+		// Act
+		result := sut.Execute()
+
+		// Assert
+		assert.Empty(t, result)
+		mockRunner.AssertExpectations(t)
+	})
+
+	t.Run("Should return list of running command ids", func(t *testing.T) {
+		// Arrange
+		mockRunner := new(test.MockRunner)
+		sut := usecases.NewGetRunningCommandIds(mockRunner)
+
+		expectedIds := []string{"cmd-1", "cmd-2", "cmd-3"}
+		mockRunner.On("GetRunningCommandIds").Return(expectedIds)
+
+		// Act
+		result := sut.Execute()
+
+		// Assert
+		assert.Equal(t, expectedIds, result)
+		assert.Len(t, result, len(expectedIds))
+		mockRunner.AssertExpectations(t)
+	})
+}

--- a/internal/command/application/usecases/test/getcommands_mock.go
+++ b/internal/command/application/usecases/test/getcommands_mock.go
@@ -1,0 +1,16 @@
+package test
+
+import (
+	"github.com/stretchr/testify/mock"
+
+	"gomander/internal/command/domain"
+)
+
+type MockGetCommands struct {
+	mock.Mock
+}
+
+func (g *MockGetCommands) Execute() ([]domain.Command, error) {
+	args := g.Called()
+	return args.Get(0).([]domain.Command), args.Error(1)
+}

--- a/internal/command/application/usecases/test/getrunningcommands_mock.go
+++ b/internal/command/application/usecases/test/getrunningcommands_mock.go
@@ -1,0 +1,12 @@
+package test
+
+import "github.com/stretchr/testify/mock"
+
+type MockGetRunningCommandIds struct {
+	mock.Mock
+}
+
+func (m *MockGetRunningCommandIds) Execute() []string {
+	args := m.Called()
+	return args.Get(0).([]string)
+}

--- a/internal/command/application/usecases/test/runcommand_mock.go
+++ b/internal/command/application/usecases/test/runcommand_mock.go
@@ -1,0 +1,12 @@
+package test
+
+import "github.com/stretchr/testify/mock"
+
+type MockRunCommands struct {
+	mock.Mock
+}
+
+func (m *MockRunCommands) Execute(commandId string) error {
+	args := m.Called(commandId)
+	return args.Error(0)
+}

--- a/internal/command/application/usecases/test/stopcommand_mock.go
+++ b/internal/command/application/usecases/test/stopcommand_mock.go
@@ -1,0 +1,12 @@
+package test
+
+import "github.com/stretchr/testify/mock"
+
+type MockStopCommand struct {
+	mock.Mock
+}
+
+func (m *MockStopCommand) Execute(commandId string) error {
+	args := m.Called(commandId)
+	return args.Error(0)
+}

--- a/internal/commandgroup/application/usecases/test/getcommandgroups_mock.go
+++ b/internal/commandgroup/application/usecases/test/getcommandgroups_mock.go
@@ -1,0 +1,16 @@
+package test
+
+import (
+	"github.com/stretchr/testify/mock"
+
+	"gomander/internal/commandgroup/domain"
+)
+
+type MockGetCommandGroups struct {
+	mock.Mock
+}
+
+func (m *MockGetCommandGroups) Execute() ([]domain.CommandGroup, error) {
+	args := m.Called()
+	return args.Get(0).([]domain.CommandGroup), args.Error(1)
+}

--- a/internal/commandgroup/application/usecases/test/runcommandgroup_mock.go
+++ b/internal/commandgroup/application/usecases/test/runcommandgroup_mock.go
@@ -1,0 +1,12 @@
+package test
+
+import "github.com/stretchr/testify/mock"
+
+type MockRunCommandGroup struct {
+	mock.Mock
+}
+
+func (m *MockRunCommandGroup) Execute(commandGroupId string) error {
+	args := m.Called(commandGroupId)
+	return args.Error(0)
+}

--- a/internal/commandgroup/application/usecases/test/stopcommandgroup_mock.go
+++ b/internal/commandgroup/application/usecases/test/stopcommandgroup_mock.go
@@ -1,0 +1,12 @@
+package test
+
+import "github.com/stretchr/testify/mock"
+
+type MockStopCommandGroup struct {
+	mock.Mock
+}
+
+func (m *MockStopCommandGroup) Execute(commandGroupId string) error {
+	args := m.Called(commandGroupId)
+	return args.Error(0)
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -41,6 +41,7 @@ type Runner interface {
 	StopRunningCommand(id string) error
 	StopAllRunningCommands() []error
 	StopRunningCommands(commands []domain.Command) error
+	GetRunningCommandIds() []string
 }
 
 func NewDefaultRunner(logger logger.Logger, emitter event.EventEmitter) *DefaultRunner {
@@ -268,4 +269,15 @@ func (c *DefaultRunner) WaitForCommand(commandId string) {
 	} else {
 		return
 	}
+}
+
+func (c *DefaultRunner) GetRunningCommandIds() []string {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	ids := make([]string, 0, len(c.runningCommands))
+	for id := range c.runningCommands {
+		ids = append(ids, id)
+	}
+	return ids
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -494,7 +494,6 @@ func TestDefaultRunner_GetRunningCommandIds(t *testing.T) {
 
 		// Assert
 		assert.Empty(t, result)
-		assert.Equal(t, 0, len(result))
 	})
 
 	t.Run("Should return list of running command ids", func(t *testing.T) {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -476,6 +476,69 @@ func TestDefaultRunner_StopRunningCommands(t *testing.T) {
 	})
 }
 
+func TestDefaultRunner_GetRunningCommandIds(t *testing.T) {
+	t.Run("Should return empty list when no commands are running", func(t *testing.T) {
+		// Arrange
+		logger := new(test.MockLogger)
+		logger.On("Info", mock.Anything).Return()
+		logger.On("Debug", mock.Anything).Return()
+		logger.On("Error", mock.Anything).Return()
+
+		emitter := new(test2.MockEventEmitter)
+		emitter.On("EmitEvent", mock.Anything, mock.Anything).Return()
+
+		sut := runner.NewDefaultRunner(logger, emitter)
+
+		// Act
+		result := sut.GetRunningCommandIds()
+
+		// Assert
+		assert.Empty(t, result)
+		assert.Equal(t, 0, len(result))
+	})
+
+	t.Run("Should return list of running command ids", func(t *testing.T) {
+		// Arrange
+		logger := new(test.MockLogger)
+		logger.On("Info", mock.Anything).Return()
+		logger.On("Debug", mock.Anything).Return()
+		logger.On("Error", mock.Anything).Return()
+
+		emitter := new(test2.MockEventEmitter)
+		emitter.On("EmitEvent", mock.Anything, mock.Anything).Return()
+
+		sut := runner.NewDefaultRunner(logger, emitter)
+
+		// Create a few commands that will run for a short time
+		command1 := &commanddomain.Command{
+			Id:      "cmd-1",
+			Command: infiniteCmd(),
+		}
+		command2 := &commanddomain.Command{
+			Id:      "cmd-2",
+			Command: infiniteCmd(),
+		}
+
+		// Start the commands
+		_ = sut.RunCommand(command1, []string{}, validWorkingDirectory())
+		_ = sut.RunCommand(command2, []string{}, validWorkingDirectory())
+
+		// Give them a moment to start
+		time.Sleep(10 * time.Millisecond)
+
+		// Act
+		result := sut.GetRunningCommandIds()
+
+		// Assert
+		assert.Len(t, result, 2)
+		assert.Contains(t, result, "cmd-1")
+		assert.Contains(t, result, "cmd-2")
+
+		// Wait for the commands to finish so we don't affect other tests
+		time.Sleep(200 * time.Millisecond)
+	})
+}
+
 func mockEmitterLogEntry(emitter *test2.MockEventEmitter, id string, line string) {
 	if runtime.GOOS == "windows" {
 		emitter.On("EmitEvent", event.NewLogEntry, map[string]string{

--- a/internal/runner/test/runner_mock.go
+++ b/internal/runner/test/runner_mock.go
@@ -34,3 +34,8 @@ func (m *MockRunner) StopAllRunningCommands() []error {
 	args := m.Called()
 	return args.Get(0).([]error)
 }
+
+func (m *MockRunner) GetRunningCommandIds() []string {
+	args := m.Called()
+	return args.Get(0).([]string)
+}


### PR DESCRIPTION
This pull request introduces a major new feature: a REST API for third-party integration with Gomander, enabling external applications to interact with commands and command groups programmatically. It also refactors how command log cleanup is triggered and adds backend support for querying running commands. Below are the most important changes:

**Third-Party API Integration**

* Added a new REST API server (`thirdpartyserver`) that starts automatically on an available port (9001-9100), exposing endpoints for command and command group management, including discovery, listing, running, and stopping commands/groups. [[1]](diffhunk://#diff-28a636ce2698d0b3febcdcebb5a62960925e68affd13fda4f3761bc9659bd3bbR1-R94) [[2]](diffhunk://#diff-f8ef22c2d4fc1d6a7b0abf0d408de4dcc1793cb04dd118134c9e40773d31bdbfR1-R152)
* Provided a full OpenAPI specification for the new API, documenting endpoints, parameters, responses, and error codes in `openapi.yaml`.
* Updated `README.md` with documentation for the third-party API, including usage instructions and endpoint descriptions.

**Backend Enhancements**

* Implemented a new use case `GetRunningCommandIds` to allow querying which commands are currently running, and integrated it into the application dependency graph. [[1]](diffhunk://#diff-135cc6425a33c911c5f288fd1653532804a118d40bf5b216e54aa51dc9fd5fd5R1-R21) [[2]](diffhunk://#diff-8c3b31d203de7539cf0fb4ccee21b40c0d804dd38ff99fc67ad18fc0d52361e7R63) [[3]](diffhunk://#diff-fa8d99c124194106cdff9d09be4a702194b62c3c0f0908962354b7e39b824055R227) [[4]](diffhunk://#diff-fa8d99c124194106cdff9d09be4a702194b62c3c0f0908962354b7e39b824055R283) [[5]](diffhunk://#diff-0932f7afa4aaf5aa938e5423771bf7018e5e512a54961679f47ac65836691785R32)
* Added unit tests for `GetRunningCommandIds` to ensure correct behavior.

**Frontend/UX Improvements**

* Refactored frontend logic so that command log cleanup now occurs when a command process starts (via event listener), rather than preemptively when running commands or command groups. [[1]](diffhunk://#diff-de0fc9126e12b83c9929767c593304216ecbc8c9c23e11b03aa3dfa17189e9a9R9) [[2]](diffhunk://#diff-de0fc9126e12b83c9929767c593304216ecbc8c9c23e11b03aa3dfa17189e9a9L49-R53) [[3]](diffhunk://#diff-cce28efc5154186e67960ae6331daef4d6ddb53cef50fa488a86085175d55fdfL2-L6) [[4]](diffhunk://#diff-a313f95428173abbf8ae2dade39564c63cd4e8d089ef72ee22ac1e35c130b4bbL2-L10)

**Miscellaneous**

* Updated `codecov.yml` to ignore coverage for main entrypoint files, focusing coverage reporting on core logic.
* Integrated the new API server into the main application startup sequence. [[1]](diffhunk://#diff-fa8d99c124194106cdff9d09be4a702194b62c3c0f0908962354b7e39b824055R15) [[2]](diffhunk://#diff-fa8d99c124194106cdff9d09be4a702194b62c3c0f0908962354b7e39b824055R87-R97)

These changes collectively make Gomander much more extensible and ready for integration with external tooling and automation platforms.