### PR TITLE
feat(i18n): implement backend core for internationalization

### DIFF
--- a/cmd/gomander/controllers.go
+++ b/cmd/gomander/controllers.go
@@ -5,6 +5,7 @@ import (
 	commanddomain "gomander/internal/command/domain"
 	commandgroupdomain "gomander/internal/commandgroup/domain"
 	configdomain "gomander/internal/config/domain"
+	localizationdomain "gomander/internal/localization/domain"
 	projectdomain "gomander/internal/project/domain"
 )
 
@@ -138,4 +139,14 @@ func (wc *WailsControllers) RunCommandController(commandId string) error {
 
 func (wc *WailsControllers) StopCommandController(commandId string) error {
 	return wc.useCases.StopCommand.Execute(commandId)
+}
+
+// Localization controllers
+
+func (wc *WailsControllers) GetTranslationController(locale string) (*localizationdomain.Localization, error) {
+	return wc.useCases.GetTranslation.Execute(locale)
+}
+
+func (wc *WailsControllers) GetSupportedLanguagesController() ([]string, error) {
+	return wc.useCases.GetSupportedLanguages.Execute()
 }

--- a/cmd/gomander/frontend/src/contracts/service.ts
+++ b/cmd/gomander/frontend/src/contracts/service.ts
@@ -15,6 +15,8 @@ import {
   GetCommandsController,
   GetCurrentProjectController,
   GetProjectToImportController,
+  GetSupportedLanguagesController,
+  GetTranslationController,
   GetUserConfigController,
   ImportProjectController,
   OpenProjectController,
@@ -84,4 +86,9 @@ export const eventService = {
 
 export const externalBrowserService = {
   browserOpenURL: BrowserOpenURL,
+};
+
+export const translationsService = {
+  getTranslation: GetTranslationController,
+  getSupportedLanguages: GetSupportedLanguagesController,
 };

--- a/cmd/gomander/frontend/src/queries/loadAllProjectData.ts
+++ b/cmd/gomander/frontend/src/queries/loadAllProjectData.ts
@@ -1,3 +1,4 @@
+import { translationsService } from "@/contracts/service";
 import { fetchCommandGroups } from "@/queries/fetchCommandGroups.ts";
 import { fetchCommands } from "@/queries/fetchCommands.ts";
 import { fetchProject } from "@/queries/fetchProject.ts";
@@ -5,4 +6,12 @@ import { fetchProject } from "@/queries/fetchProject.ts";
 export const loadAllProjectData = async () => {
   await Promise.all([fetchCommands(), fetchCommandGroups()]);
   await fetchProject();
+
+  // TODO: Delete this (testing i18n PoC)
+  const languages = await translationsService.getSupportedLanguages();
+  console.log("languages: ", languages);
+
+  const translations = await translationsService.getTranslation('es-ES');
+  console.log("translations: ", translations)
+  console.log("sidebar title: ", translations["sidebar.title"])
 };

--- a/cmd/gomander/frontend/src/screens/SettingsScreen/contexts/settingsContext.tsx
+++ b/cmd/gomander/frontend/src/screens/SettingsScreen/contexts/settingsContext.tsx
@@ -95,6 +95,7 @@ export const SettingsContextProvider = ({
         await saveUserConfig({
           lastOpenedProjectId: userConfig.lastOpenedProjectId,
           environmentPaths: formData.environmentPaths,
+          locale: 'en-GB', // TODO: add this to formData
         });
         toast.success("User settings saved successfully");
       } catch (e) {

--- a/cmd/gomander/frontend/src/store/userConfigurationStore.ts
+++ b/cmd/gomander/frontend/src/store/userConfigurationStore.ts
@@ -13,6 +13,7 @@ export const userConfigurationStore = createStore<UserConfigurationStore>()(
     userConfig: {
       environmentPaths: [],
       lastOpenedProjectId: "",
+      locale: "",
     },
     setUserConfig: (config: UserConfig) => {
       set({ userConfig: config });

--- a/cmd/gomander/frontend/wailsjs/go/main/WailsControllers.d.ts
+++ b/cmd/gomander/frontend/wailsjs/go/main/WailsControllers.d.ts
@@ -32,6 +32,10 @@ export function GetCurrentProjectController():Promise<domain.Project>;
 
 export function GetProjectToImportController():Promise<domain.ProjectExportJSONv1>;
 
+export function GetSupportedLanguagesController():Promise<Array<string>>;
+
+export function GetTranslationController(arg1:string):Promise<domain.Localization>;
+
 export function GetUserConfigController():Promise<domain.Config>;
 
 export function ImportProjectController(arg1:domain.ProjectExportJSONv1,arg2:string,arg3:string):Promise<void>;

--- a/cmd/gomander/frontend/wailsjs/go/main/WailsControllers.js
+++ b/cmd/gomander/frontend/wailsjs/go/main/WailsControllers.js
@@ -62,6 +62,14 @@ export function GetProjectToImportController() {
   return window['go']['main']['WailsControllers']['GetProjectToImportController']();
 }
 
+export function GetSupportedLanguagesController() {
+  return window['go']['main']['WailsControllers']['GetSupportedLanguagesController']();
+}
+
+export function GetTranslationController(arg1) {
+  return window['go']['main']['WailsControllers']['GetTranslationController'](arg1);
+}
+
 export function GetUserConfigController() {
   return window['go']['main']['WailsControllers']['GetUserConfigController']();
 }

--- a/cmd/gomander/frontend/wailsjs/go/models.ts
+++ b/cmd/gomander/frontend/wailsjs/go/models.ts
@@ -3,6 +3,8 @@ export namespace app {
 	export interface UseCases {
 	    GetUserConfig: any;
 	    SaveUserConfig: any;
+	    GetTranslation: any;
+	    GetSupportedLanguages: any;
 	    GetCurrentProject: any;
 	    GetAvailableProjects: any;
 	    OpenProject: any;
@@ -89,8 +91,17 @@ export namespace domain {
 	export interface Config {
 	    lastOpenedProjectId: string;
 	    environmentPaths: EnvironmentPath[];
+	    locale: string;
 	}
 	
+	export interface Localization {
+	    "sidebar.title": string;
+	    "sidebar.minimize": string;
+	    "actions.cancel": string;
+	    "actions.save": string;
+	    "toast.test.success": string;
+	    "toast.test.error": string;
+	}
 	export interface Project {
 	    id: string;
 	    name: string;

--- a/cmd/gomander/locales/en-GB.json
+++ b/cmd/gomander/locales/en-GB.json
@@ -1,0 +1,10 @@
+{
+  "sidebar.title": "Commands",
+  "sidebar.minimize": "Minimize",
+
+  "actions.cancel": "Cancel",
+  "actions.save": "Save",
+
+  "toast.test.success": "Test operation completed successfully",
+  "toast.test.error": "Test operation failed"
+}

--- a/cmd/gomander/locales/es-ES.json
+++ b/cmd/gomander/locales/es-ES.json
@@ -1,0 +1,10 @@
+{
+  "sidebar.title": "Comandos",
+  "sidebar.minimize": "Minimizar",
+
+  "actions.cancel": "Cancelar",
+  "actions.save": "Guardar",
+
+  "toast.test.success": "Operación de prueba completada con éxito",
+  "toast.test.error": "La operación de prueba falló"
+}

--- a/cmd/gomander/main.go
+++ b/cmd/gomander/main.go
@@ -22,6 +22,7 @@ import (
 	configusecases "gomander/internal/config/application/usecases"
 	configinfrastructure "gomander/internal/config/infrastructure"
 	"gomander/internal/eventbus"
+	localizationusecases "gomander/internal/localization/application/usecases"
 	"gomander/internal/facade"
 	"gomander/internal/logger"
 	projectusecases "gomander/internal/project/application/usecases"
@@ -42,6 +43,9 @@ import (
 
 //go:embed all:frontend/dist
 var assets embed.FS
+
+//go:embed locales
+var localeFs embed.FS
 
 const ConfigFolderPathName = "gomander"
 
@@ -195,6 +199,9 @@ func registerDeps(gormDb *gorm.DB, ctx context.Context, app *internalapp.App) {
 	// Configuration
 	getUserConfig := configusecases.NewGetUserConfig(configRepo)
 	saveUserConfig := configusecases.NewSaveUserConfig(configRepo)
+	// Localization
+	getTranslation := localizationusecases.NewGetTranslation(localeFs)
+	getSupportedLanguages := localizationusecases.NewGetSupportedLanguages(localeFs)
 	// Projects
 	getCurrentProject := projectusecases.NewGetCurrentProject(configRepo, projectRepo)
 	getAvailableProjects := projectusecases.NewGetAvailableProjects(projectRepo)
@@ -251,6 +258,9 @@ func registerDeps(gormDb *gorm.DB, ctx context.Context, app *internalapp.App) {
 			// Configuration
 			GetUserConfig:  getUserConfig,
 			SaveUserConfig: saveUserConfig,
+			// Localization
+			GetTranslation:        getTranslation,
+			GetSupportedLanguages: getSupportedLanguages,
 			// Projects
 			GetCurrentProject:    getCurrentProject,
 			GetAvailableProjects: getAvailableProjects,

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -12,6 +12,7 @@ import (
 	configusecases "gomander/internal/config/application/usecases"
 	configdomain "gomander/internal/config/domain"
 	"gomander/internal/event"
+	localizationusecases "gomander/internal/localization/application/usecases"
 	"gomander/internal/eventbus"
 	"gomander/internal/facade"
 	"gomander/internal/logger"
@@ -31,6 +32,9 @@ type UseCases struct {
 	// Configuration
 	GetUserConfig  configusecases.GetUserConfig
 	SaveUserConfig configusecases.SaveUserConfig
+	// Localization
+	GetTranslation        localizationusecases.GetTranslation
+	GetSupportedLanguages localizationusecases.GetSupportedLanguages
 	// Projects
 	GetCurrentProject    projectusecases.GetCurrentProject
 	GetAvailableProjects projectusecases.GetAvailableProjects

--- a/internal/config/domain/config.go
+++ b/internal/config/domain/config.go
@@ -8,4 +8,5 @@ type EnvironmentPath struct {
 type Config struct {
 	LastOpenedProjectId string            `json:"lastOpenedProjectId"`
 	EnvironmentPaths    []EnvironmentPath `json:"environmentPaths"`
+	Locale              string            `json:"locale"`
 }

--- a/internal/config/infrastructure/mapper.go
+++ b/internal/config/infrastructure/mapper.go
@@ -10,6 +10,7 @@ func ToDomainConfig(model *ConfigModel, paths []EnvironmentPathModel) *domain.Co
 	config := &domain.Config{
 		LastOpenedProjectId: model.LastOpenedProjectId,
 		EnvironmentPaths:    make([]domain.EnvironmentPath, 0),
+		Locale:              model.Locale,
 	}
 
 	for _, pathModel := range paths {
@@ -30,6 +31,7 @@ func ToModelConfig(config *domain.Config) (*ConfigModel, []EnvironmentPathModel)
 	model := &ConfigModel{
 		Id:                  1,
 		LastOpenedProjectId: config.LastOpenedProjectId,
+		Locale:              config.Locale,
 	}
 
 	var pathModels []EnvironmentPathModel

--- a/internal/config/infrastructure/model.go
+++ b/internal/config/infrastructure/model.go
@@ -3,6 +3,7 @@ package infrastructure
 type ConfigModel struct {
 	Id                  int    `gorm:"primaryKey;column:id"`
 	LastOpenedProjectId string `gorm:"column:last_opened_project_id"`
+	Locale              string `gorm:"column:locale"`
 }
 
 func (ConfigModel) TableName() string {

--- a/internal/localization/application/usecases/getsupportedlanguages.go
+++ b/internal/localization/application/usecases/getsupportedlanguages.go
@@ -1,0 +1,39 @@
+package usecases
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"strings"
+)
+
+type GetSupportedLanguages interface {
+	Execute() ([]string, error)
+}
+
+type DefaultGetSupportedLanguages struct {
+	localeFs embed.FS
+}
+
+func NewGetSupportedLanguages(localeFs embed.FS) *DefaultGetSupportedLanguages {
+	return &DefaultGetSupportedLanguages{
+		localeFs: localeFs,
+	}
+}
+
+func (uc *DefaultGetSupportedLanguages) Execute() ([]string, error) {
+	dirEntries, err := fs.ReadDir(uc.localeFs, "locales")
+	if err != nil {
+		return nil, fmt.Errorf("read locales directory: %w", err)
+	}
+
+	languages := make([]string, 0, len(dirEntries))
+	for _, d := range dirEntries {
+		if !d.IsDir() && strings.HasSuffix(d.Name(), ".json") {
+			languageCode := strings.TrimSuffix(d.Name(), ".json")
+			languages = append(languages, languageCode)
+		}
+	}
+
+	return languages, nil
+}

--- a/internal/localization/application/usecases/gettranslation.go
+++ b/internal/localization/application/usecases/gettranslation.go
@@ -1,0 +1,37 @@
+package usecases
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+
+	"gomander/internal/localization/domain"
+)
+
+type GetTranslation interface {
+	Execute(locale string) (*domain.Localization, error)
+}
+
+type DefaultGetTranslation struct {
+	localeFs embed.FS
+}
+
+func NewGetTranslation(localeFs embed.FS) *DefaultGetTranslation {
+	return &DefaultGetTranslation{
+		localeFs: localeFs,
+	}
+}
+
+func (uc *DefaultGetTranslation) Execute(locale string) (*domain.Localization, error) {
+	localeJson, err := uc.localeFs.ReadFile(fmt.Sprintf("locales/%s.json", locale))
+	if err != nil {
+		return nil, fmt.Errorf("read locale json: %w", err)
+	}
+
+	var lng domain.Localization
+	if err := json.Unmarshal(localeJson, &lng); err != nil {
+		return nil, fmt.Errorf("unmarshal locale json: %w", err)
+	}
+
+	return &lng, nil
+}

--- a/internal/localization/domain/localization.go
+++ b/internal/localization/domain/localization.go
@@ -1,0 +1,13 @@
+package domain
+
+type Localization struct {
+	// PoC: Only a few keys for testing
+	SidebarTitle    string `json:"sidebar.title"`
+	SidebarMinimize string `json:"sidebar.minimize"`
+
+	ActionsCancel string `json:"actions.cancel"`
+	ActionsSave   string `json:"actions.save"`
+
+	ToastTestSuccess string `json:"toast.test.success"`
+	ToastTestError   string `json:"toast.test.error"`
+}

--- a/migrations/20250920192100_add_locale_to_user_config.go
+++ b/migrations/20250920192100_add_locale_to_user_config.go
@@ -1,0 +1,29 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upAddLocaleToUserConfig, downAddLocaleToUserConfig)
+}
+
+func upAddLocaleToUserConfig(ctx context.Context, tx *sql.Tx) error {
+	// This code is executed when the migration is applied.
+	_, err := tx.ExecContext(ctx, `
+		ALTER TABLE user_config ADD COLUMN locale TEXT DEFAULT 'en-GB';
+	`)
+
+	return err
+}
+
+func downAddLocaleToUserConfig(ctx context.Context, tx *sql.Tx) error {
+	// This code is executed when the migration is rolled back.
+	_, err := tx.ExecContext(ctx, `
+		ALTER TABLE user_config DROP COLUMN locale;
+	`)
+	return err
+}


### PR DESCRIPTION
This PR introduces the backend foundation for internationalization support in Gomander.

## What's implemented

- **Config domain extension**: Added `locale` field to user configuration
- **Database migration**: New migration to add locale column to user_config table  
- **Localization domain**: Created new domain with translation structure and use cases
- **Wails integration**: Added controllers and frontend service layer for i18n
- **Basic translations**: Added en-GB and es-ES JSON files with sample keys for testing

The PoC is functional and can be tested through `translationsService` in the frontend.

## Next steps in this PR

- [ ] Add backend localization tests

## Upcoming stacked PRs

1. **i18next frontend integration**: Implement React i18next provider and hook up translation loading
2. **Settings UI**: Add language selector to settings form with persistence  
3. **Full translation coverage**: Populate translation files and replace hardcoded strings throughout the app

## Testing

The current implementation can be tested via browser console:
```js
const langs = await translationsService.getSupportedLanguages()
const translations = await translationsService.getTranslation('es-ES')
```